### PR TITLE
Hide run code button during generation

### DIFF
--- a/src/components/ConversationReview/PreConversation.jsx
+++ b/src/components/ConversationReview/PreConversation.jsx
@@ -82,7 +82,7 @@ export const transcriptDisplay = {
   },
 };
 
-const newTheme = {
+const createTheme = (hideRunButton) => ({
   p: (props) => <Text mb={2} lineHeight="1.6" {...props} />,
   ul: (props) => <UnorderedList pl={6} spacing={2} {...props} />,
   ol: (props) => <UnorderedList as="ol" pl={6} spacing={2} {...props} />,
@@ -93,7 +93,10 @@ const newTheme = {
   code: ({ inline, className, children, ...props }) => {
     const match = /language-(\w+)/.exec(className || "");
     return !inline && match ? (
-      <LiveReactEditorModal code={String(children).replace(/\n$/, "")} />
+      <LiveReactEditorModal
+        code={String(children).replace(/\n$/, "")}
+        hideRunButton={hideRunButton}
+      />
     ) : (
       <Box
         as="code"
@@ -107,7 +110,7 @@ const newTheme = {
       </Box>
     );
   },
-};
+});
 
 const renderGroupedSteps = (steps, currentStep, userLanguage) => {
   const groups = {};
@@ -290,7 +293,10 @@ const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
       )}
       {code && (
         <Box width="100%" p={4} borderRadius="md">
-          <Markdown components={ChakraUIRenderer(newTheme)} children={code} />
+          <Markdown
+            components={ChakraUIRenderer(createTheme(isLoading))}
+            children={code}
+          />
         </Box>
       )}
     </VStack>

--- a/src/components/ConversationReview/PreConversation.jsx
+++ b/src/components/ConversationReview/PreConversation.jsx
@@ -250,7 +250,8 @@ const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
   return (
     <VStack
       spacing={4}
-      alignItems="flex-start"
+      // alignItems="flex-start"
+
       width="100%"
       maxWidth="600px"
       mt="20px"
@@ -270,6 +271,7 @@ const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
         backgroundColor="white"
         boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
         marginTop="-20px"
+        width="75%"
       />
       <HStack>
         <Button
@@ -301,13 +303,33 @@ const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
         <Text>{translation[userLanguage]["loading.suggestion"]}</Text>
       )}
       {code && (
-        <LiveEditorContext.Provider
-          value={{ hideRunButton: isLoading, autoRun: !isLoading }}
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          width="100%"
+          justifyContent={"center"}
         >
-          <Box width="100%" p={4} borderRadius="md">
-            <Markdown components={ChakraUIRenderer(newTheme)} children={code} />
-          </Box>
-        </LiveEditorContext.Provider>
+          <LiveEditorContext.Provider
+            value={{ hideRunButton: isLoading, autoRun: !isLoading }}
+          >
+            <Box width="100%" p={4} borderRadius="md">
+              <Markdown
+                components={ChakraUIRenderer(newTheme)}
+                children={code}
+              />
+            </Box>
+          </LiveEditorContext.Provider>
+          <HStack>
+            <Button
+              onClick={handleSave}
+              isDisabled={!code.trim()}
+              boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
+            >
+              {translation[userLanguage]["nextStep"]}
+            </Button>
+          </HStack>
+        </Box>
       )}
     </VStack>
   );

--- a/src/components/LiveCodeEditor/LiveCodeEditor.jsx
+++ b/src/components/LiveCodeEditor/LiveCodeEditor.jsx
@@ -85,7 +85,11 @@ import { translation } from "../../utility/translation";
 // ;
 // `;
 
-const LiveReactEditorModal = ({ code, isOnboarding = false }) => {
+const LiveReactEditorModal = ({
+  code,
+  isOnboarding = false,
+  hideRunButton = false,
+}) => {
   const [editorCode, setEditorCode] = useState(code);
   const { hasCopied, onCopy } = useClipboard(
     editorCode +
@@ -202,15 +206,17 @@ const LiveReactEditorModal = ({ code, isOnboarding = false }) => {
   console.log("isreact", isReactCode(editorCode));
   return (
     <>
-      <Button
-        variant="outline"
-        mt={4}
-        onClick={runCode}
-        mb={4}
-        boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
-      >
-        Run Code
-      </Button>
+      {!hideRunButton && (
+        <Button
+          variant="outline"
+          mt={4}
+          onClick={runCode}
+          mb={4}
+          boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
+        >
+          Run Code
+        </Button>
+      )}
       {/* {!isOnboarding && (
         <>
           {" "}

--- a/src/components/LiveCodeEditor/LiveCodeEditor.jsx
+++ b/src/components/LiveCodeEditor/LiveCodeEditor.jsx
@@ -89,6 +89,7 @@ const LiveReactEditorModal = ({
   code,
   isOnboarding = false,
   hideRunButton = false,
+  autoRun = false,
 }) => {
   const [editorCode, setEditorCode] = useState(code);
   const { hasCopied, onCopy } = useClipboard(
@@ -106,6 +107,13 @@ const LiveReactEditorModal = ({
     }
     setEditorCode(code);
   }, [code]);
+
+  useEffect(() => {
+    if (autoRun && editorCode.trim()) {
+      runCode();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoRun]);
 
   const isReactCode = (code) =>
     /(ReactDOM\s*\.\s*)?render\s*\(\s*<\s*[A-Z][\w]*\s*\/?>/.test(code);

--- a/src/components/LiveCodeEditor/LiveCodeEditor.jsx
+++ b/src/components/LiveCodeEditor/LiveCodeEditor.jsx
@@ -211,10 +211,9 @@ const LiveReactEditorModal = ({
   //   md: isOnboarding ? "100%" : "100%",
   // });
 
-  console.log("isreact", isReactCode(editorCode));
   return (
     <>
-      {!hideRunButton && (
+      {/* {!hideRunButton && (
         <Button
           variant="outline"
           mt={4}
@@ -224,7 +223,7 @@ const LiveReactEditorModal = ({
         >
           Run Code
         </Button>
-      )}
+      )} */}
       {/* {!isOnboarding && (
         <>
           {" "}
@@ -283,7 +282,12 @@ const LiveReactEditorModal = ({
           />
         </Box>
 
-        <Box width={"100%"} borderRadius="md">
+        <Box
+          width={"100%"}
+          borderRadius="2xl"
+          marginTop="8px"
+          border="1px solid black"
+        >
           {isReactCode(editorCode) && isPreviewing ? (
             <ChakraProvider>
               <LiveProvider


### PR DESCRIPTION
## Summary
- add an optional `hideRunButton` prop to `LiveReactEditorModal`
- update PreConversation to pass that flag while code is generating

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686acbcbb3708326a22d82b31e4936c4