### PR TITLE
Render Gemini thinking summaries

### DIFF
--- a/src/components/ConversationReview/PreConversation.jsx
+++ b/src/components/ConversationReview/PreConversation.jsx
@@ -365,6 +365,11 @@ const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
       {isLoading && (
         <>
           <CloudCanvas />
+          {messages.length > 0 && (
+            <Text fontSize="sm" whiteSpace="pre-wrap">
+              {messages[messages.length - 1].thought}
+            </Text>
+          )}
           <Text>{translation[userLanguage]["loading.suggestion"]}</Text>
         </>
       )}


### PR DESCRIPTION
## Summary
- stream with `includeThoughts` enabled for PreConversation
- surface partial thinking text during loading to improve feedback

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_686e9affbcb48326a0efdb3499f6ded4