### PR TITLE
Fix pink theme switch

### DIFF
--- a/src/useThemeStore.jsx
+++ b/src/useThemeStore.jsx
@@ -15,6 +15,17 @@ const shades = [
   "900",
 ];
 const applyTheme = (color) => {
+  if (color === "pink") {
+    // Remove overrides so default pink values are restored
+    shades.forEach((s) =>
+      document.documentElement.style.removeProperty(
+        `--chakra-colors-pink-${s}`
+      )
+    );
+    document.documentElement.style.removeProperty("--chakra-colors-pink");
+    return;
+  }
+
   shades.forEach((s) => {
     document.documentElement.style.setProperty(
       `--chakra-colors-pink-${s}`,


### PR DESCRIPTION
## Summary
- fix theme switching when returning to the default pink color

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c4909df008326bb16e55a19c23b97