### PR TITLE
Fix pink theme switch

### DIFF
--- a/src/components/ThemeMenu.jsx
+++ b/src/components/ThemeMenu.jsx
@@ -16,6 +16,15 @@ import { ChevronDownIcon } from "@chakra-ui/icons";
 import { translation } from "../utility/translation";
 
 const colors = ["purple", "orange", "green", "blue", "yellow", "pink"];
+// Map each color to its base hex so menu swatches don't change with theme
+const bubbleColors = {
+  purple: "#9f7aea",
+  orange: "#ed8936",
+  green: "#48bb78",
+  blue: "#4299e1",
+  yellow: "#ecc94b",
+  pink: "#ed64a6",
+};
 
 const ThemeMenu = ({ userLanguage, isIcon = true, buttonProps = {} }) => {
   const themeColor = useThemeStore((s) => s.themeColor);
@@ -45,7 +54,7 @@ const ThemeMenu = ({ userLanguage, isIcon = true, buttonProps = {} }) => {
             }}
           >
             <HStack>
-              <Box w={3} h={3} borderRadius="full" bg={`${c}.400`} />
+              <Box w={3} h={3} borderRadius="full" bg={bubbleColors[c]} />
               <Text>{translation[userLanguage][`settings.theme.${c}`]}</Text>
             </HStack>
           </MenuItem>

--- a/src/useThemeStore.jsx
+++ b/src/useThemeStore.jsx
@@ -15,6 +15,17 @@ const shades = [
   "900",
 ];
 const applyTheme = (color) => {
+  if (color === "pink") {
+    // Remove overrides so default pink values are restored
+    shades.forEach((s) =>
+      document.documentElement.style.removeProperty(
+        `--chakra-colors-pink-${s}`
+      )
+    );
+    document.documentElement.style.removeProperty("--chakra-colors-pink");
+    return;
+  }
+
   shades.forEach((s) => {
     document.documentElement.style.setProperty(
       `--chakra-colors-pink-${s}`,


### PR DESCRIPTION
## Summary
- keep color bubbles in theme menu static

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c4909df008326bb16e55a19c23b97