### PR TITLE
Add multi-course selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -570,7 +570,7 @@ export const VoiceInput = ({
       if (step.isConversationReview) {
         const relevantSteps = getObjectsByGroup(
           step?.group,
-          steps[stepKey]
+          steps[userCourse][userLanguage]
         );
 
         submitPrompt(
@@ -659,7 +659,7 @@ export const VoiceInput = ({
         }`
       );
     } else {
-      const relevantSteps = getObjectsByGroup(step?.group, steps[stepKey]);
+      const relevantSteps = getObjectsByGroup(step?.group, steps[userCourse][userLanguage]);
 
       submitEducationalPrompt(
         `Generate educational material about ${JSON.stringify(
@@ -1373,8 +1373,7 @@ const Step = ({
   const [grade, setGrade] = useState("");
   const [isTimerExpired, setIsTimerExpired] = useState(true);
 
-  const stepKey = `${userCourse}-${userLanguage}`;
-  const [step, setStep] = useState(steps[stepKey][currentStep]);
+  const [step, setStep] = useState(steps[userCourse][userLanguage][currentStep]);
 
   const { resetMessages, messages, submitPrompt } = useChatCompletion({
     response_format: { type: "json_object" },
@@ -1494,7 +1493,7 @@ const Step = ({
   } = useChatCompletion({});
 
   useEffect(() => {
-    setStep(steps[stepKey][currentStep]);
+    setStep(steps[userCourse][userLanguage][currentStep]);
     const generateSuggestionForNewStep = async () => {
       setSuggestionLoading(true);
       try {
@@ -1507,7 +1506,7 @@ const Step = ({
         };
 
         // const userAnswers = await fetchUserAnswers();
-        const subjectsCompleted = steps[stepKey]
+        const subjectsCompleted = steps[userCourse][userLanguage]
           .slice(1, currentStep) // All completed steps
           .map((step) => step.title);
 
@@ -1665,7 +1664,7 @@ const Step = ({
     // console.log("generatedQuestion", generatedQuestion);
 
     if (isEmpty(generatedQuestion) && isEmpty(newQuestionMessages)) {
-      const stepContent = steps[stepKey][currentStep];
+      const stepContent = steps[userCourse][userLanguage][currentStep];
       setStep(stepContent);
     }
 
@@ -1681,7 +1680,7 @@ const Step = ({
         };
 
         const userAnswers = await fetchUserAnswers();
-        const subjectsCompleted = steps[stepKey]
+        const subjectsCompleted = steps[userCourse][userLanguage]
           .slice(1, currentStep) // All completed steps
           .map((step) => step.title);
 
@@ -1726,7 +1725,7 @@ const Step = ({
         };
 
         const userAnswers = await fetchUserAnswers();
-        const subjectsCompleted = steps[stepKey]
+        const subjectsCompleted = steps[userCourse][userLanguage]
           .slice(1, currentStep) // All completed steps
           .map((step) => step.title);
 
@@ -1819,7 +1818,7 @@ const Step = ({
 
   // Calculate progress through the steps
   const calculateProgress = () => {
-    let result = ((currentStep - 1) / (steps[stepKey].length - 1)) * 100;
+    let result = ((currentStep - 1) / (steps[userCourse][userLanguage].length - 1)) * 100;
     if (result < 0) return 0;
     return result;
   };
@@ -1871,7 +1870,7 @@ const Step = ({
 
     if (step.isConversationReview) {
       // console.log("review");
-      const relevantSteps = getObjectsByGroup(step?.group, steps[stepKey]);
+      const relevantSteps = getObjectsByGroup(step?.group, steps[userCourse][userLanguage]);
 
       await submitPrompt(
         [
@@ -2241,7 +2240,7 @@ const Step = ({
           setIsPostingWithNostr(false);
         }
       }
-    } else if (currentStep >= steps[stepKey].length - 1) {
+    } else if (currentStep >= steps[userCourse][userLanguage].length - 1) {
       const npub = localStorage.getItem("local_npub");
       await incrementToFinalAward(npub);
       navigate("/award");
@@ -2532,7 +2531,7 @@ const Step = ({
     };
 
     const getUserAnsweredSubjects = () => {
-      let list = steps[stepKey];
+      let list = steps[userCourse][userLanguage];
       let subjects = [];
       for (let i = 1; i < list.length; i++) {
         if (i <= currentStep - 1) {
@@ -2555,7 +2554,7 @@ const Step = ({
         )},
 
 
-        The request: Create/invent a completely new and custom adaptive question and feel free to explore creativity using the same interface with group, title, description, <question_type> and the custom question object interface. Here are the types of question_types (e.g isMultipleChoice, isCodeCompletion) and their respective question objects that we've used in the tutorial group, so that you can understand how questions are designed to encourage variance in learning: ${JSON.stringify(getObjectsByGroup("tutorial", steps[stepKey]))}. It is extremely important to understand that the data types used in the "answer" field are specific and must not change under any circumstance, or else the request will fail due to unexpected data type.
+        The request: Create/invent a completely new and custom adaptive question and feel free to explore creativity using the same interface with group, title, description, <question_type> and the custom question object interface. Here are the types of question_types (e.g isMultipleChoice, isCodeCompletion) and their respective question objects that we've used in the tutorial group, so that you can understand how questions are designed to encourage variance in learning: ${JSON.stringify(getObjectsByGroup("tutorial", steps[userCourse][userLanguage]))}. It is extremely important to understand that the data types used in the "answer" field are specific and must not change under any circumstance, or else the request will fail due to unexpected data type.
         
         Remember to design and inspire a new question, you must select a different but valid question_type than the one you've received, strictly based on the interfaces ive provided with the tutorials. Do not deviate and create a new question type or else the UI will fail with your response. 
         
@@ -2964,7 +2963,7 @@ const Step = ({
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
                           />
-                          {steps[stepKey]
+                          {steps[userCourse][userLanguage]
                             .map((s, idx) => ({ s, idx }))
                             .filter(({ s, idx }) => {
                               const term = searchTerm.toLowerCase();
@@ -5276,7 +5275,7 @@ function App({ isShutDown }) {
             currentStep={currentStep} // Pass current step to SettingsMenu
             view={view}
             setView={setView}
-            step={steps?.[stepKey]?.[currentStep]}
+            step={steps?.[userCourse]?.[userLanguage]?.[currentStep]}
             allowPosts={allowPosts}
             setAllowPosts={setAllowPosts}
           />
@@ -5330,7 +5329,7 @@ function App({ isShutDown }) {
             }
           />
           {location.pathname !== "/about" &&
-            steps?.[stepKey]?.map((_, index) => (
+            steps?.[userCourse]?.[userLanguage]?.map((_, index) => (
               <Route
                 key={index}
                 path={`/q/${index}`}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2215,7 +2215,12 @@ const Step = ({
     //
     if (currentStep === 9) {
       const npub = localStorage.getItem("local_npub");
-      setUserCourse(localStorage.getItem("userCourse") || "compsci");
+      setUserCourse(
+        (localStorage.getItem("userCourse") || "coding").replace(
+          "compsci",
+          "coding"
+        )
+      );
 
       if (
         localStorage.getItem("passcode") !==
@@ -4966,7 +4971,7 @@ function App({ isShutDown }) {
   const [currentStep, setCurrentStep] = useState(0); // State to store current step
   const [userLanguage, setUserLanguage] = useState("en"); // State to store user language preference
   const [userCourse, setUserCourse] = useState(
-    localStorage.getItem("userCourse") || "compsci"
+    (localStorage.getItem("userCourse") || "coding").replace("compsci", "coding")
   );
   const navigate = useNavigate();
   const location = useLocation();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3781,6 +3781,8 @@ const Home = ({
   setIsSignedIn,
   userLanguage,
   setUserLanguage,
+  userCourse,
+  setUserCourse,
   generateNostrKeys,
   auth,
   view,
@@ -3815,6 +3817,12 @@ const Home = ({
   const socket = "socket";
   const [role, setRole] = useState("chores");
   const topRef = useRef();
+
+  const handleCourseChange = (e) => {
+    const value = e.target.value;
+    setUserCourse(value);
+    localStorage.setItem("userCourse", value);
+  };
 
   useEffect(() => {
     let index = 0;
@@ -3873,6 +3881,7 @@ const Home = ({
     const startTime = Date.now();
 
     setShowSplash(true);
+    localStorage.setItem("userCourse", userCourse);
     let accs = parseInt(localStorage.getItem("accs") || "0", 10);
 
     // Check if the user has already generated 3 questions
@@ -3937,6 +3946,7 @@ const Home = ({
   const handleSignIn = async () => {
     try {
       setIsSigningIn(true);
+      localStorage.setItem("userCourse", userCourse);
       try {
         await auth(secretKey);
       } catch (error) {
@@ -4177,6 +4187,24 @@ const Home = ({
               onChange={(e) => setUserName(e.target.value)}
               backgroundColor="white"
             />
+
+            <Select
+              value={userCourse}
+              onChange={handleCourseChange}
+              maxWidth={300}
+              backgroundColor="white"
+              boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
+            >
+              <option value="coding">
+                {translation[userLanguage]["course.coding"]}
+              </option>
+              <option value="maya">
+                {translation[userLanguage]["course.maya"]}
+              </option>
+              <option value="civics">
+                {translation[userLanguage]["course.civics"]}
+              </option>
+            </Select>
 
             <VStack>
               <Button
@@ -5296,6 +5324,8 @@ function App({ isShutDown }) {
                 setIsSignedIn={setIsSignedIn}
                 userLanguage={userLanguage}
                 setUserLanguage={setUserLanguage}
+                userCourse={userCourse}
+                setUserCourse={setUserCourse}
                 generateNostrKeys={generateNostrKeys}
                 auth={auth}
                 view={view}

--- a/src/components/ConversationReview/ConversationReview.jsx
+++ b/src/components/ConversationReview/ConversationReview.jsx
@@ -80,16 +80,17 @@ const newTheme = {
 };
 
 const ConversationReview = ({
+const ConversationReview = ({
   question,
   userLanguage,
   steps,
+  userCourse,
   onSubmit,
   step,
   setFinalConversation,
   finalConversation,
   handleModalCheck,
 }) => {
-  const [response, setResponse] = useState("");
   const [conversation, setConversation] = useState([]);
   const [streamingResponse, setStreamingResponse] = useState("");
   const { resetMessages, messages, submitPrompt } = useSimpleGeminiChat();
@@ -129,7 +130,7 @@ const ConversationReview = ({
   // console.log("step", step);
   // console.log("step.group", step?.group);
 
-  const relevantSteps = getObjectsByGroup(step?.group, steps[userLanguage]);
+  const relevantSteps = getObjectsByGroup(step?.group, steps[userCourse][userLanguage]);
 
   // console.log("relevant steps", relevantSteps);
 
@@ -216,6 +217,7 @@ const ConversationReview = ({
         steps={steps}
         step={step}
         userLanguage={userLanguage}
+        userCourse={userCourse}
         onContinue={() => setShowIntro(false)}
       />
     );

--- a/src/components/ConversationReview/ConversationReview.jsx
+++ b/src/components/ConversationReview/ConversationReview.jsx
@@ -80,7 +80,6 @@ const newTheme = {
 };
 
 const ConversationReview = ({
-const ConversationReview = ({
   question,
   userLanguage,
   steps,

--- a/src/components/ConversationReview/PreConversation.jsx
+++ b/src/components/ConversationReview/PreConversation.jsx
@@ -134,7 +134,7 @@ const newTheme = {
 
 const renderGroupedSteps = (steps, currentStep, userLanguage) => {
   const groups = {};
-  steps[userLanguage].forEach((s, index) => {
+  steps[userCourse][userLanguage].forEach((s, index) => {
     if (!groups[s.group]) groups[s.group] = [];
     groups[s.group].push({ ...s, index });
   });
@@ -166,7 +166,7 @@ const renderGroupedSteps = (steps, currentStep, userLanguage) => {
   });
 };
 
-const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
+const PreConversation = ({ steps, step, userLanguage, userCourse, onContinue }) => {
   const [idea, setIdea] = useState("");
   const [savedIdea, setSavedIdea] = useState("");
   const [code, setCode] = useState("");
@@ -233,8 +233,8 @@ const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
   const handleGenerate = async () => {
     setIsLoading(true);
     resetMessages();
-    const idx = steps[userLanguage].indexOf(step);
-    const completed = steps[userLanguage].slice(1, idx).map((s) => s.title);
+    const idx = steps[userCourse][userLanguage].indexOf(step);
+    const completed = steps[userCourse][userLanguage].slice(1, idx).map((s) => s.title);
     const history = await fetchHistory();
 
     console.log("completed..", completed);
@@ -308,7 +308,7 @@ const PreConversation = ({ steps, step, userLanguage, onContinue }) => {
     onContinue();
   };
 
-  const currentIdx = steps[userLanguage].indexOf(step);
+  const currentIdx = steps[userCourse][userLanguage].indexOf(step);
   return (
     <VStack
       spacing={4}

--- a/src/components/Landing/Landing.jsx
+++ b/src/components/Landing/Landing.jsx
@@ -8,6 +8,7 @@ import {
   Button,
   FormControl,
   FormLabel,
+  Select,
   Switch,
   useToast,
 } from "@chakra-ui/react";
@@ -36,6 +37,15 @@ export const Landing = ({
   const [loadingMessage, setLoadingMessage] = useState(
     "createAccount.isCreating"
   );
+  const [selectedCourse, setSelectedCourse] = useState(
+    localStorage.getItem("userCourse") || "compsci"
+  );
+
+  const handleCourseChange = (e) => {
+    const value = e.target.value;
+    setSelectedCourse(value);
+    localStorage.setItem("userCourse", value);
+  };
 
   const toast = useToast();
   const navigate = useNavigate();
@@ -71,6 +81,24 @@ export const Landing = ({
         backgroundColor="white"
         boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
       />
+
+      <Select
+        value={selectedCourse}
+        onChange={handleCourseChange}
+        maxWidth={300}
+        backgroundColor="white"
+        boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
+      >
+        <option value="compsci">
+          {translation[userLanguage]["course.compsci"]}
+        </option>
+        <option value="maya">
+          {translation[userLanguage]["course.maya"]}
+        </option>
+        <option value="civics">
+          {translation[userLanguage]["course.civics"]}
+        </option>
+      </Select>
 
       <HStack spacing={4}>
         <Button

--- a/src/components/Landing/Landing.jsx
+++ b/src/components/Landing/Landing.jsx
@@ -38,7 +38,7 @@ export const Landing = ({
     "createAccount.isCreating"
   );
   const [selectedCourse, setSelectedCourse] = useState(
-    localStorage.getItem("userCourse") || "compsci"
+    (localStorage.getItem("userCourse") || "coding").replace("compsci", "coding")
   );
 
   const handleCourseChange = (e) => {
@@ -89,8 +89,8 @@ export const Landing = ({
         backgroundColor="white"
         boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
       >
-        <option value="compsci">
-          {translation[userLanguage]["course.compsci"]}
+        <option value="coding">
+          {translation[userLanguage]["course.coding"]}
         </option>
         <option value="maya">
           {translation[userLanguage]["course.maya"]}

--- a/src/components/Landing/Landing.jsx
+++ b/src/components/Landing/Landing.jsx
@@ -8,7 +8,6 @@ import {
   Button,
   FormControl,
   FormLabel,
-  Select,
   Switch,
   useToast,
 } from "@chakra-ui/react";
@@ -37,15 +36,6 @@ export const Landing = ({
   const [loadingMessage, setLoadingMessage] = useState(
     "createAccount.isCreating"
   );
-  const [selectedCourse, setSelectedCourse] = useState(
-    (localStorage.getItem("userCourse") || "coding").replace("compsci", "coding")
-  );
-
-  const handleCourseChange = (e) => {
-    const value = e.target.value;
-    setSelectedCourse(value);
-    localStorage.setItem("userCourse", value);
-  };
 
   const toast = useToast();
   const navigate = useNavigate();
@@ -82,23 +72,6 @@ export const Landing = ({
         boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
       />
 
-      <Select
-        value={selectedCourse}
-        onChange={handleCourseChange}
-        maxWidth={300}
-        backgroundColor="white"
-        boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
-      >
-        <option value="coding">
-          {translation[userLanguage]["course.coding"]}
-        </option>
-        <option value="maya">
-          {translation[userLanguage]["course.maya"]}
-        </option>
-        <option value="civics">
-          {translation[userLanguage]["course.civics"]}
-        </option>
-      </Select>
 
       <HStack spacing={4}>
         <Button

--- a/src/components/LectureModal/LectureModal.jsx
+++ b/src/components/LectureModal/LectureModal.jsx
@@ -130,7 +130,7 @@ const ProgressDisplay = ({
   );
 };
 
-const LectureModal = ({ isOpen, onClose, currentStep, userLanguage }) => {
+const LectureModal = ({ isOpen, onClose, currentStep, userLanguage, userCourse }) => {
   const { getLastNotesByNpub, assignExistingBadgeToNpub } = useSharedNostr(
     localStorage.getItem("local_npub"),
     localStorage.getItem("local_nsec")
@@ -150,7 +150,7 @@ const LectureModal = ({ isOpen, onClose, currentStep, userLanguage }) => {
   const videoRef = useRef(null);
   const [isVideoPlaying, setIsVideoPlaying] = useState(false);
 
-  const step = steps[userLanguage][currentStep];
+  const step = steps[userCourse][userLanguage][currentStep];
 
   const transcriptObject =
     step.group === "introduction"

--- a/src/components/ProgressModal/ProgressModal.jsx
+++ b/src/components/ProgressModal/ProgressModal.jsx
@@ -23,9 +23,8 @@ const ProgressModal = ({
   steps,
   currentStep,
   userLanguage,
+  userCourse,
 }) => {
-  const transcriptDisplay = {
-    introduction: {
       en: "Tutorial",
       es: "Tutorial",
       "py-en": "Tutorial",
@@ -91,7 +90,7 @@ const ProgressModal = ({
   };
 
   // build a list of all steps (exclude index 0 placeholder)
-  const allSteps = steps[userLanguage]
+  const allSteps = steps[userCourse][userLanguage]
     .map((step, idx) => ({ step, idx }))
     .filter(({ idx }) => idx > 0);
 

--- a/src/components/ProgressModal/ProgressModal.jsx
+++ b/src/components/ProgressModal/ProgressModal.jsx
@@ -25,6 +25,8 @@ const ProgressModal = ({
   userLanguage,
   userCourse,
 }) => {
+  const transcriptDisplay = {
+    introduction: {
       en: "Tutorial",
       es: "Tutorial",
       "py-en": "Tutorial",

--- a/src/components/SettingsMenu/KnowledgeLedgerModal/KnowledgeLedgerModal.jsx
+++ b/src/components/SettingsMenu/KnowledgeLedgerModal/KnowledgeLedgerModal.jsx
@@ -155,6 +155,7 @@ export const KnowledgeLedgerModal = ({
   steps,
   currentStep,
   userLanguage,
+  userCourse,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [suggestion, setSuggestion] = useState("");
@@ -182,7 +183,7 @@ export const KnowledgeLedgerModal = ({
     try {
       const userId = localStorage.getItem("local_npub");
       if (!userId) return;
-      const group = steps[userLanguage][currentStep].group;
+      const group = steps[userCourse][userLanguage][currentStep].group;
       await setDoc(
         doc(database, "users", userId, "buildHistory", group),
         {
@@ -284,7 +285,7 @@ export const KnowledgeLedgerModal = ({
         .filter(
           (d) =>
             !isNaN(parseInt(d.id)) &&
-            parseInt(d.id) < parseInt(steps[userLanguage][currentStep].group),
+            parseInt(d.id) < parseInt(steps[userCourse][userLanguage][currentStep].group),
         )
         .sort((a, b) => parseInt(a.id) - parseInt(b.id))
         .map((d) => d.data().code)
@@ -316,11 +317,11 @@ export const KnowledgeLedgerModal = ({
     try {
       // const userAnswers = await fetchUserAnswers();
 
-      const subjectsCompleted = steps[userLanguage]
+      const subjectsCompleted = steps[userCourse][userLanguage]
         .slice(1, currentStep) // All completed steps
         .map((step) => step.title);
 
-      const totalSteps = steps[userLanguage].map((step) => step.title);
+      const totalSteps = steps[userCourse][userLanguage].map((step) => step.title);
 
       console.log("json completed", JSON.stringify(subjectsCompleted, null, 2));
 
@@ -387,7 +388,7 @@ export const KnowledgeLedgerModal = ({
   const renderGroupedSteps = () => {
     const stepElements = [];
     let lastGroup = null;
-    steps[userLanguage].forEach((step, index) => {
+    steps[userCourse][userLanguage].forEach((step, index) => {
       if (step.group !== lastGroup) {
         stepElements.push(
           step.group === "introduction" ? null : (

--- a/src/components/SettingsMenu/SettingsMenu.jsx
+++ b/src/components/SettingsMenu/SettingsMenu.jsx
@@ -56,6 +56,7 @@ const SettingsMenu = ({
   isSignedIn,
   setIsSignedIn,
   steps,
+  userCourse,
   currentStep,
   userLanguage,
   setUserLanguage,
@@ -798,7 +799,7 @@ const SettingsMenu = ({
         <StudyGuideModal
           isOpen={isStudyGuideModalOpen}
           onClose={onStudyGuideModalClose}
-          content={steps[userLanguage][0].question.metaData}
+          content={steps[`${userCourse}-${userLanguage}`][0].question.metaData}
           userLanguage={userLanguage}
         />
       ) : null}

--- a/src/components/SettingsMenu/SettingsMenu.jsx
+++ b/src/components/SettingsMenu/SettingsMenu.jsx
@@ -387,7 +387,7 @@ const SettingsMenu = ({
                       <MenuItem
                         p={6}
                         onClick={() =>
-                          handleLanguageSelect({ target: { value: "java-en" } })
+                          handleLanguageSelect({ target: { value: "android-en" } })
                         }
                       >
                         Java & Android (English)

--- a/src/components/SettingsMenu/SettingsMenu.jsx
+++ b/src/components/SettingsMenu/SettingsMenu.jsx
@@ -799,7 +799,7 @@ const SettingsMenu = ({
         <StudyGuideModal
           isOpen={isStudyGuideModalOpen}
           onClose={onStudyGuideModalClose}
-          content={steps[`${userCourse}-${userLanguage}`][0].question.metaData}
+          content={steps[userCourse][userLanguage][0].question.metaData}
           userLanguage={userLanguage}
         />
       ) : null}

--- a/src/utility/content.jsx
+++ b/src/utility/content.jsx
@@ -6837,6 +6837,77 @@ console.log(arr);
     },
   ],
 
+  "maya-en": [
+    {
+      group: "introduction",
+      title: "Maya History Overview",
+      description: "When did the Classic period of Maya history begin?",
+      isMultipleChoice: true,
+      question: {
+        questionText:
+          "Which region is most closely associated with the ancient Maya?",
+        options: [
+          "Andes Mountains",
+          "Mesoamerica",
+          "Sahara Desert",
+          "Mesopotamia",
+        ],
+        answer: ["Mesoamerica"],
+      },
+    },
+    {
+      group: "language",
+      title: "Maya Writing",
+      description: "Recognize the nature of Maya script.",
+      isMultipleChoice: true,
+      question: {
+        questionText: "The Maya writing system is best described as:",
+        options: [
+          "Alphabetic",
+          "Hieroglyphic",
+          "Numeric",
+          "Phoenician",
+        ],
+        answer: ["Hieroglyphic"],
+      },
+    },
+  ],
+
+  "civics-en": [
+    {
+      group: "introduction",
+      title: "U.S. Civics Basics",
+      description: "Prepare for the U.S. citizenship civics test.",
+      isMultipleChoice: true,
+      question: {
+        questionText: "What is the supreme law of the land?",
+        options: [
+          "The President",
+          "The Constitution",
+          "Congress",
+          "The States",
+        ],
+        answer: ["The Constitution"],
+      },
+    },
+    {
+      group: "government",
+      title: "Branches of Government",
+      description: "Identify a branch of the U.S. government.",
+      isMultipleChoice: true,
+      question: {
+        questionText: "Which of the following is one branch of the U.S. government?",
+        options: [
+          "Economic",
+          "Legislative",
+          "Technological",
+          "Educational",
+        ],
+        answer: ["Legislative"],
+      },
+    },
+  ],
+
   "py-en": [
     {
       group: "introduction",

--- a/src/utility/content.jsx
+++ b/src/utility/content.jsx
@@ -2,7 +2,7 @@ export const getObjectsByGroup = (groupNumber, arrayOfObjects) => {
   return arrayOfObjects.filter((obj) => obj.group === groupNumber);
 };
 
-export const steps = {
+export const flatSteps = {
   "compsci-en": [
     {
       group: "introduction",
@@ -13237,6 +13237,7 @@ doc.delete();`,
 
   // ],
 };
+export const steps = Object.entries(flatSteps).reduce((acc,[key,val])=>{const [course,lang]=key.split("-");acc[course]=acc[course]||{};acc[course][lang]=val;return acc;},{});
 
 export const lectureSummaries = {
   en: {

--- a/src/utility/content.jsx
+++ b/src/utility/content.jsx
@@ -13237,7 +13237,20 @@ doc.delete();`,
 
   // ],
 };
-export const steps = Object.entries(flatSteps).reduce((acc,[key,val])=>{const [course,lang]=key.split("-");acc[course]=acc[course]||{};acc[course][lang]=val;return acc;},{});
+export const steps = Object.entries(flatSteps).reduce((acc, [key, val]) => {
+  let [rawCourse] = key.split("-");
+  const courseMap = {
+    compsci: "coding",
+    py: "coding",
+    swift: "coding",
+    android: "coding",
+  };
+
+  const course = courseMap[rawCourse] || rawCourse;
+  acc[course] = acc[course] || {};
+  acc[course][key] = val;
+  return acc;
+}, {});
 
 export const lectureSummaries = {
   en: {

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -13,7 +13,7 @@ export const pickProgrammingLanguage = (language) => {
   return languages[language];
 };
 
-export let translation = {
+const baseTranslation = {
   en: {
     startTutorialAndOnboarding:
       "Let's start the tutorial and account setup next.",
@@ -9542,3 +9542,16 @@ reverse(head) {
     "tag.allowPosting": "Do not post my progress",
   },
 };
+
+export const translations = {
+  compsci: baseTranslation,
+  maya: baseTranslation,
+  civics: baseTranslation,
+};
+
+export const translation = new Proxy({}, {
+  get(_, lang) {
+    const course = typeof localStorage !== "undefined" ? localStorage.getItem("userCourse") || "compsci" : "compsci";
+    return translations[course][lang];
+  },
+});

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -18,6 +18,9 @@ export let translation = {
     startTutorialAndOnboarding:
       "Let's start the tutorial and account setup next.",
     "language.compsci.english": "Computer Science (Python)",
+    "course.compsci": "Coding",
+    "course.maya": "Maya Language & History",
+    "course.civics": "Civics Exam Prep",
     "languageToggle.english": "English",
     "languageToggle.spanish": "Español",
     "landing.whyLearn.title": "Why Learn With Robots Building Education?",
@@ -1622,6 +1625,9 @@ reverse(head) {
     "Sorting & Searching Algorithms": "Algoritmos de Ordenamiento y Búsqueda",
     "Operating Systems Essentials": "Fundamentos de Sistemas Operativos",
     "language.compsci.spanish": "Ciencias de la Computación (Python en Inglés)",
+    "course.compsci": "Programación",
+    "course.maya": "Idioma e Historia Maya",
+    "course.civics": "Preparación para el examen cívico",
 
     "languageToggle.english": "Inglés",
     "languageToggle.spanish": "Español",

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -18,7 +18,7 @@ const baseTranslation = {
     startTutorialAndOnboarding:
       "Let's start the tutorial and account setup next.",
     "language.compsci.english": "Computer Science (Python)",
-    "course.compsci": "Coding",
+    "course.coding": "Coding",
     "course.maya": "Maya Language & History",
     "course.civics": "Civics Exam Prep",
     "languageToggle.english": "English",
@@ -1625,7 +1625,7 @@ reverse(head) {
     "Sorting & Searching Algorithms": "Algoritmos de Ordenamiento y Búsqueda",
     "Operating Systems Essentials": "Fundamentos de Sistemas Operativos",
     "language.compsci.spanish": "Ciencias de la Computación (Python en Inglés)",
-    "course.compsci": "Programación",
+    "course.coding": "Programación",
     "course.maya": "Idioma e Historia Maya",
     "course.civics": "Preparación para el examen cívico",
 
@@ -9544,14 +9544,17 @@ reverse(head) {
 };
 
 export const translations = {
-  compsci: baseTranslation,
+  coding: baseTranslation,
   maya: baseTranslation,
   civics: baseTranslation,
 };
 
 export const translation = new Proxy({}, {
   get(_, lang) {
-    const course = typeof localStorage !== "undefined" ? localStorage.getItem("userCourse") || "compsci" : "compsci";
+    const course =
+      typeof localStorage !== "undefined"
+        ? localStorage.getItem("userCourse") || "coding"
+        : "coding";
     return translations[course][lang];
   },
 });


### PR DESCRIPTION
## Summary
- add course dropdown on landing page
- handle course state in app and step components
- support new civics and Maya question sets
- translate course names for English and Spanish

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6884446e47a4832696d27673b27e7543