### PR TITLE
feat: animate question progress bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1842,7 +1842,7 @@ const Step = ({
     const newProgress = calculateProgress();
     const controls = animate(previousProgressRef.current, newProgress, {
       duration: 0.8,
-      ease: "easeOut",
+      ease: "easeInOut",
       onUpdate: (v) => setAnimatedProgress(v),
     });
     previousProgressRef.current = newProgress;
@@ -1851,7 +1851,7 @@ const Step = ({
 
   useEffect(() => {
     progressControls.start({
-      scale: [1, 1.1, 1],
+      scale: [1, 1.025, 1],
       boxShadow: [
         "0.5px 0.5px 1px 0px rgba(0,0,0,0.75)",
         "0 0 8px rgba(255,215,0,0.8)",
@@ -2642,10 +2642,6 @@ const Step = ({
     localStorage.getItem("passcode") ===
       import.meta.env.VITE_PATREON_PASSCODE || hasSubmittedPasscode;
 
-  console.log(
-    "               {loot[currentStep][userLanguage]}",
-    loot[currentStep][userLanguage]
-  );
   return (
     <VStack spacing={4} width="100%" mt={6} p={4}>
       {/* <OrbCanvas width={500} height={500} /> */}
@@ -2869,51 +2865,55 @@ const Step = ({
               </Box>
               <br />
             </span>
-            <span style={{ fontSize: "50%" }}>
-              {translation[userLanguage]["app.progress"]}:{" "}
-              {animatedProgress.toFixed(2)}% |{" "}
-              {translation[userLanguage]["chapter"]}: {step.group}&nbsp;|&nbsp;
-              {translation[userLanguage]["app.streak"]}: {streak}
-              &nbsp;|&nbsp;{translation[userLanguage]["goal"] + "s"}:{" "}
-              {String(goalCount) || "0"}
-              &nbsp;
-            </span>
-            <MotionProgress
-              initial={{ scale: 1 }}
-              animate={progressControls}
-              opacity="0.8"
-              value={animatedProgress}
-              size="md"
-              colorScheme={getColorScheme(step.group)}
-              width="80%"
-              hasStripe
-              isAnimated
-              borderRadius="4px"
-              border="1px solid #ececec"
-              boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
-              background={getBackgroundScheme(step.group)}
-              mb={userLanguage !== "compsci-en" ? 0 : 4}
-              sx={{
-                "& > div": {
-                  background: "linear-gradient(270deg, #f6ad55, #fbd38d, #f6ad55)",
-                  backgroundSize: "200% 200%",
-                  animation: `${progressGradient} 60s linear infinite`,
-                },
-              }}
-            />
-            {userLanguage !== "compsci-en" ? (
-              <Text
-                color="yellow.600"
-                fontWeight={"bold"}
-                style={{ fontSize: "50%", marginBottom: "4px" }}
-              >
-                {translation[userLanguage]["skillValue"]}$
-                {currentStep === 0 || currentStep === 1
-                  ? 0
-                  : loot[currentStep - 1]["monetaryValue"]}
-              </Text>
-            ) : null}
-
+            <VStack width="100%">
+              <span style={{ fontSize: "50%" }}>
+                {translation[userLanguage]["app.progress"]}:{" "}
+                {animatedProgress.toFixed(2)}% |{" "}
+                {translation[userLanguage]["chapter"]}: {step.group}
+                &nbsp;|&nbsp;
+                {translation[userLanguage]["app.streak"]}: {streak}
+                &nbsp;|&nbsp;{translation[userLanguage]["goal"] + "s"}:{" "}
+                {String(goalCount) || "0"}
+                &nbsp;
+              </span>
+              <MotionProgress
+                height="20px"
+                initial={{ scale: 1 }}
+                animate={progressControls}
+                opacity="0.8"
+                value={animatedProgress}
+                size="md"
+                colorScheme={getColorScheme(step.group)}
+                width="80%"
+                hasStripe
+                isAnimated
+                borderRadius="4px"
+                border="1px solid #ececec"
+                boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
+                background={getBackgroundScheme(step.group)}
+                mb={userLanguage !== "compsci-en" ? 0 : 4}
+                sx={{
+                  "& > div": {
+                    background:
+                      "linear-gradient(270deg, #f6ad55, #fbd38d, #f6ad55)",
+                    backgroundSize: "200% 200%",
+                    animation: `${progressGradient} 7s ease-in-out  infinite`,
+                  },
+                }}
+              />
+              {userLanguage !== "compsci-en" ? (
+                <Text
+                  color="yellow.600"
+                  fontWeight={"bold"}
+                  style={{ fontSize: "50%", marginBottom: "4px" }}
+                >
+                  {translation[userLanguage]["skillValue"]}$
+                  {currentStep === 0 || currentStep === 1
+                    ? 0
+                    : loot[currentStep - 1]["monetaryValue"]}
+                </Text>
+              ) : null}
+            </VStack>
             {/* {calculateBalance() > 0 ? (
               <HStack
                 style={{ marginTop: "-12px", width: "100%" }}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,6 @@ import {
   MenuItem,
   Tooltip,
   Center,
-  keyframes,
 } from "@chakra-ui/react";
 import MonacoEditor from "@monaco-editor/react";
 import ReactBash from "react-bash";
@@ -170,6 +169,7 @@ import { newTheme } from "./App.theme";
 import { InstallAppModal } from "./components/InstallModal/InstallModal";
 
 import { motion, animate, useAnimation } from "framer-motion";
+import { keyframes } from "@emotion/react";
 import { Delaunay } from "d3-delaunay";
 import StudyGuideModal from "./components/StudyGuideModal/StudyGuideModal";
 import { CodeEditor } from "./components/CodeEditor/CodeEditor";
@@ -210,7 +210,7 @@ const applySymbolMappings = (text) => {
 
 const progressGradient = keyframes`
   0% { background-position: 0% 50%; }
-  100% { background-position: 100% 50%; }
+  100% { background-position: 200% 50%; }
 `;
 
 const MotionProgress = motion(Progress);
@@ -2897,7 +2897,7 @@ const Step = ({
                 "& > div": {
                   background: "linear-gradient(270deg, #f6ad55, #fbd38d, #f6ad55)",
                   backgroundSize: "200% 200%",
-                  animation: `${progressGradient} 2s linear infinite`,
+                  animation: `${progressGradient} 60s linear infinite`,
                 },
               }}
             />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import {
   MenuItem,
   Tooltip,
   Center,
+  keyframes,
 } from "@chakra-ui/react";
 import MonacoEditor from "@monaco-editor/react";
 import ReactBash from "react-bash";
@@ -206,6 +207,13 @@ const applySymbolMappings = (text) => {
   });
   return modifiedText;
 };
+
+const progressGradient = keyframes`
+  0% { background-position: 0% 50%; }
+  100% { background-position: 100% 50%; }
+`;
+
+const MotionProgress = motion(Progress);
 
 const getBoxShadow = (group) => {
   switch (group) {
@@ -2857,27 +2865,38 @@ const Step = ({
               {String(goalCount) || "0"}
               &nbsp;
             </span>
-            <motion.div
+            <MotionProgress
               key={currentStep}
               initial={{ scale: 1 }}
-              animate={{ scale: [1, 1.1, 1] }}
+              animate={{
+                scale: [1, 1.1, 1],
+                boxShadow: [
+                  "0 0 0px rgba(255,215,0,0)",
+                  "0 0 8px rgba(255,215,0,0.8)",
+                  "0 0 0px rgba(255,215,0,0)",
+                ],
+              }}
               transition={{ duration: 0.6 }}
-            >
-              <Progress
-                opacity="0.8"
-                value={animatedProgress}
-                size="md"
-                colorScheme={getColorScheme(step.group)}
-                width="80%"
-                hasStripe
-                isAnimated
-                borderRadius="4px"
-                border="1px solid #ececec"
-                boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
-                background={getBackgroundScheme(step.group)}
-                mb={userLanguage !== "compsci-en" ? 0 : 4}
-              />
-            </motion.div>
+              opacity="0.8"
+              value={animatedProgress}
+              size="md"
+              colorScheme={getColorScheme(step.group)}
+              width="80%"
+              hasStripe
+              isAnimated
+              borderRadius="4px"
+              border="1px solid #ececec"
+              boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
+              background={getBackgroundScheme(step.group)}
+              mb={userLanguage !== "compsci-en" ? 0 : 4}
+              sx={{
+                "& > div": {
+                  background: "linear-gradient(270deg, #f6ad55, #fbd38d, #f6ad55)",
+                  backgroundSize: "200% 200%",
+                  animation: `${progressGradient} 2s linear infinite`,
+                },
+              }}
+            />
             {userLanguage !== "compsci-en" ? (
               <Text
                 color="yellow.600"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -168,7 +168,7 @@ import { Onboarding } from "./Onboarding";
 import { newTheme } from "./App.theme";
 import { InstallAppModal } from "./components/InstallModal/InstallModal";
 
-import { motion } from "framer-motion";
+import { motion, animate } from "framer-motion";
 import { Delaunay } from "d3-delaunay";
 import StudyGuideModal from "./components/StudyGuideModal/StudyGuideModal";
 import { CodeEditor } from "./components/CodeEditor/CodeEditor";
@@ -1826,6 +1826,20 @@ const Step = ({
     return result;
   };
 
+  const [animatedProgress, setAnimatedProgress] = useState(calculateProgress());
+  const previousProgressRef = useRef(calculateProgress());
+
+  useEffect(() => {
+    const newProgress = calculateProgress();
+    const controls = animate(previousProgressRef.current, newProgress, {
+      duration: 0.8,
+      ease: "easeOut",
+      onUpdate: (v) => setAnimatedProgress(v),
+    });
+    previousProgressRef.current = newProgress;
+    return () => controls.stop();
+  }, [currentStep]);
+
   // Handle input change
   const handleInputChange = (value, resetter = null) => {
     setInputValue(value);
@@ -2836,27 +2850,34 @@ const Step = ({
             </span>
             <span style={{ fontSize: "50%" }}>
               {translation[userLanguage]["app.progress"]}:{" "}
-              {calculateProgress().toFixed(2)}% |{" "}
+              {animatedProgress.toFixed(2)}% |{" "}
               {translation[userLanguage]["chapter"]}: {step.group}&nbsp;|&nbsp;
               {translation[userLanguage]["app.streak"]}: {streak}
               &nbsp;|&nbsp;{translation[userLanguage]["goal"] + "s"}:{" "}
               {String(goalCount) || "0"}
               &nbsp;
             </span>
-            <Progress
-              opacity="0.8"
-              value={calculateProgress()}
-              size="md"
-              colorScheme={getColorScheme(step.group)}
-              width="80%"
-              // mb={4}
-              borderRadius="4px"
-              border="1px solid #ececec"
-              // boxShadow="0px 0px 0.5px 2px #ececec"
-              boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
-              background={getBackgroundScheme(step.group)}
-              mb={userLanguage !== "compsci-en" ? 0 : 4}
-            />
+            <motion.div
+              key={currentStep}
+              initial={{ scale: 1 }}
+              animate={{ scale: [1, 1.1, 1] }}
+              transition={{ duration: 0.6 }}
+            >
+              <Progress
+                opacity="0.8"
+                value={animatedProgress}
+                size="md"
+                colorScheme={getColorScheme(step.group)}
+                width="80%"
+                hasStripe
+                isAnimated
+                borderRadius="4px"
+                border="1px solid #ececec"
+                boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
+                background={getBackgroundScheme(step.group)}
+                mb={userLanguage !== "compsci-en" ? 0 : 4}
+              />
+            </motion.div>
             {userLanguage !== "compsci-en" ? (
               <Text
                 color="yellow.600"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,7 @@ import { Onboarding } from "./Onboarding";
 import { newTheme } from "./App.theme";
 import { InstallAppModal } from "./components/InstallModal/InstallModal";
 
-import { motion, animate } from "framer-motion";
+import { motion, animate, useAnimation } from "framer-motion";
 import { Delaunay } from "d3-delaunay";
 import StudyGuideModal from "./components/StudyGuideModal/StudyGuideModal";
 import { CodeEditor } from "./components/CodeEditor/CodeEditor";
@@ -1836,6 +1836,7 @@ const Step = ({
 
   const [animatedProgress, setAnimatedProgress] = useState(calculateProgress());
   const previousProgressRef = useRef(calculateProgress());
+  const progressControls = useAnimation();
 
   useEffect(() => {
     const newProgress = calculateProgress();
@@ -1847,6 +1848,18 @@ const Step = ({
     previousProgressRef.current = newProgress;
     return () => controls.stop();
   }, [currentStep]);
+
+  useEffect(() => {
+    progressControls.start({
+      scale: [1, 1.1, 1],
+      boxShadow: [
+        "0.5px 0.5px 1px 0px rgba(0,0,0,0.75)",
+        "0 0 8px rgba(255,215,0,0.8)",
+        "0.5px 0.5px 1px 0px rgba(0,0,0,0.75)",
+      ],
+      transition: { duration: 0.6 },
+    });
+  }, [currentStep, progressControls]);
 
   // Handle input change
   const handleInputChange = (value, resetter = null) => {
@@ -2866,17 +2879,8 @@ const Step = ({
               &nbsp;
             </span>
             <MotionProgress
-              key={currentStep}
               initial={{ scale: 1 }}
-              animate={{
-                scale: [1, 1.1, 1],
-                boxShadow: [
-                  "0 0 0px rgba(255,215,0,0)",
-                  "0 0 8px rgba(255,215,0,0.8)",
-                  "0 0 0px rgba(255,215,0,0)",
-                ],
-              }}
-              transition={{ duration: 0.6 }}
+              animate={progressControls}
               opacity="0.8"
               value={animatedProgress}
               size="md"


### PR DESCRIPTION
## Summary
- add framer-motion animation to question progress tracking
- show striped, animated progress bar with scale effect on question change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688dcc26a5b88326bf8e62ad80467035