### PR TITLE
Gamify learn modal text and highlight key concepts

### DIFF
--- a/src/components/LearnModal/EducationalModal.jsx
+++ b/src/components/LearnModal/EducationalModal.jsx
@@ -50,13 +50,23 @@ import { isUnsupportedBrowser } from "../../utility/browser";
 import { InstallAppModal } from "../InstallModal/InstallModal";
 
 export const newTheme = {
-  p: (props) => <Text mb={2} lineHeight="1.6" {...props} />,
-  ul: (props) => <UnorderedList pl={6} spacing={2} {...props} />,
-  ol: (props) => <UnorderedList as="ol" pl={6} spacing={2} {...props} />,
-  li: (props) => <ListItem mb={1} {...props} />,
-  h1: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
-  h2: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
+  p: (props) => <Text mb={2} lineHeight="1.6" {...props} />, 
+  ul: (props) => <UnorderedList pl={6} spacing={2} {...props} />, 
+  ol: (props) => <UnorderedList as="ol" pl={6} spacing={2} {...props} />, 
+  li: (props) => <ListItem mb={1} {...props} />, 
+  h1: (props) => <Heading as="h4" mt={6} size="md" {...props} />, 
+  h2: (props) => <Heading as="h4" mt={6} size="md" {...props} />, 
   h3: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
+  strong: (props) => (
+    <Text
+      as="span"
+      bg="yellow.200"
+      px={1}
+      borderRadius="md"
+      fontWeight="bold"
+      {...props}
+    />
+  ),
   code: ({ inline, className, children, ...props }) => {
     const match = /language-(\w+)/.exec(className || "");
 
@@ -415,16 +425,12 @@ const EducationalModal = ({
                   <OrbCanvas
                     hasStreamedText={false}
                     instructions={
-                      <Text fontWeight={"bold"} fontSize="xl">
-                        {" "}
-                        {translation[userLanguage]["modal.learn.instructions"]}
-                        <br />
-                        <br />
-                        {
+                      <Markdown components={ChakraUIRenderer(newTheme)}>
+                        {`${translation[userLanguage]["modal.learn.instructions"]}\n\n${
                           educationalMessages[educationalMessages.length - 1]
-                            ?.content
-                        }
-                      </Text>
+                            ?.content || ""
+                        }`}
+                      </Markdown>
                     }
                   />
                   {/* // ) : ( // )}  */}

--- a/src/components/LearnModal/EducationalModal.jsx
+++ b/src/components/LearnModal/EducationalModal.jsx
@@ -49,26 +49,37 @@ import { LuSend } from "react-icons/lu";
 import { isUnsupportedBrowser } from "../../utility/browser";
 import { InstallAppModal } from "../InstallModal/InstallModal";
 
+const highlightColors = [
+  "green.300",
+  "yellow.300",
+  "purple.300",
+  "orange.300",
+  "blue.300",
+];
+
 export const newTheme = {
-  p: (props) => <Text mb={2} lineHeight="1.6" {...props} />, 
-  ul: (props) => <UnorderedList pl={6} spacing={2} {...props} />, 
-  ol: (props) => <UnorderedList as="ol" pl={6} spacing={2} {...props} />, 
-  li: (props) => <ListItem mb={1} {...props} />, 
-  h1: (props) => <Heading as="h4" mt={6} size="md" {...props} />, 
+  p: (props) => <Text mb={2} lineHeight="1.6" {...props} />,
+  ul: (props) => <UnorderedList pl={6} spacing={2} {...props} />,
+  ol: (props) => <UnorderedList as="ol" pl={6} spacing={2} {...props} />,
+  li: (props) => <ListItem mb={1} {...props} />,
+  h1: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
   h2: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
   h3: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
-  strong: (props) => (
-    <Text
-      as="span"
-      bgGradient="linear(to-r, purple.600, cyan.400)"
-      color="white"
-      px={1}
-      borderRadius="md"
-      fontWeight="extrabold"
-      textShadow="0 0 6px rgba(0,0,0,0.6)"
-      {...props}
-    />
-  ),
+  strong: (props) => {
+    const color =
+      highlightColors[Math.floor(Math.random() * highlightColors.length)];
+    return (
+      <Text
+        as="span"
+        bg={color}
+        color="black"
+        px={1}
+        borderRadius="md"
+        fontWeight="extrabold"
+        {...props}
+      />
+    );
+  },
   code: ({ inline, className, children, ...props }) => {
     const match = /language-(\w+)/.exec(className || "");
 
@@ -404,13 +415,9 @@ const EducationalModal = ({
                   )}
                 </div>
                 &nbsp;
-                <Text
-                  bgGradient="linear(to-r, purple.400, cyan.300)"
-                  bgClip="text"
-                  fontWeight="extrabold"
-                >
+                <div style={{ color: "white" }}>
                   {translation[userLanguage]["modal.learn.title"]}
-                </Text>
+                </div>
               </HStack>
             </ModalHeader>
 
@@ -492,13 +499,7 @@ const EducationalModal = ({
                   {/* // )} */}
                 </div>
                 &nbsp;
-                <Text
-                  bgGradient="linear(to-r, purple.400, cyan.300)"
-                  bgClip="text"
-                  fontWeight="extrabold"
-                >
-                  {translation[userLanguage]["modal.learn.title"]}
-                </Text>
+                <div>{translation[userLanguage]["modal.learn.title"]}</div>
               </HStack>
             </ModalHeader>
 

--- a/src/components/LearnModal/EducationalModal.jsx
+++ b/src/components/LearnModal/EducationalModal.jsx
@@ -55,15 +55,17 @@ export const newTheme = {
   ol: (props) => <UnorderedList as="ol" pl={6} spacing={2} {...props} />, 
   li: (props) => <ListItem mb={1} {...props} />, 
   h1: (props) => <Heading as="h4" mt={6} size="md" {...props} />, 
-  h2: (props) => <Heading as="h4" mt={6} size="md" {...props} />, 
+  h2: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
   h3: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
   strong: (props) => (
     <Text
       as="span"
-      bg="yellow.200"
+      bgGradient="linear(to-r, purple.600, cyan.400)"
+      color="white"
       px={1}
       borderRadius="md"
-      fontWeight="bold"
+      fontWeight="extrabold"
+      textShadow="0 0 6px rgba(0,0,0,0.6)"
       {...props}
     />
   ),
@@ -402,9 +404,13 @@ const EducationalModal = ({
                   )}
                 </div>
                 &nbsp;
-                <div style={{ color: "white" }}>
+                <Text
+                  bgGradient="linear(to-r, purple.400, cyan.300)"
+                  bgClip="text"
+                  fontWeight="extrabold"
+                >
                   {translation[userLanguage]["modal.learn.title"]}
-                </div>
+                </Text>
               </HStack>
             </ModalHeader>
 
@@ -486,7 +492,13 @@ const EducationalModal = ({
                   {/* // )} */}
                 </div>
                 &nbsp;
-                <div>{translation[userLanguage]["modal.learn.title"]}</div>
+                <Text
+                  bgGradient="linear(to-r, purple.400, cyan.300)"
+                  bgClip="text"
+                  fontWeight="extrabold"
+                >
+                  {translation[userLanguage]["modal.learn.title"]}
+                </Text>
               </HStack>
             </ModalHeader>
 

--- a/src/components/LearnModal/EducationalModal.jsx
+++ b/src/components/LearnModal/EducationalModal.jsx
@@ -66,8 +66,11 @@ export const newTheme = {
   h2: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
   h3: (props) => <Heading as="h4" mt={6} size="md" {...props} />,
   strong: (props) => {
-    const color =
-      highlightColors[Math.floor(Math.random() * highlightColors.length)];
+    const content = React.Children.toArray(props.children).join("");
+    const hash = content
+      .split("")
+      .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    const color = highlightColors[hash % highlightColors.length];
     return (
       <Text
         as="span"

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -1042,7 +1042,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
+      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -2787,7 +2787,7 @@ Las Estructuras de Datos y Algoritmos es una materia que a menudo intimida a los
     "modal.openSocialWallet.startButton": "Ir a la Billetera Social",
     "modal.learn.title": "¡Sube de nivel!",
     "modal.learn.instructions":
-      "🎮 ¡Prepárate! Estamos forjando tus **notas de misión**. Los conceptos clave brillarán para ganar **XP** extra!",
+      "🛡️ ¡Prepárate, héroe! Tu **registro de misión** se está cargando con colores épicos. Observa cómo los hechizos clave brillan con tonos **legendarios** para obtener **XP** extra!",
     "modal.feedback.title": "Enviar comentarios",
     "modal.feedback.contactLabel": "Contacto",
     "modal.feedback.contactPlaceholder": "Ingrese su información de contacto",
@@ -4205,7 +4205,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
+      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -5803,7 +5803,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
+      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -7401,7 +7401,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
+      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -8997,7 +8997,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
+      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -1040,9 +1040,9 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Learn",
+    "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "Give us a few seconds to create quick lesson notes.",
+      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -2785,9 +2785,9 @@ Las Estructuras de Datos y Algoritmos es una materia que a menudo intimida a los
     "modal.openSocialWallet.instructions":
       "¡No olvides tus claves antes de irte!",
     "modal.openSocialWallet.startButton": "Ir a la Billetera Social",
-    "modal.learn.title": "Aprender",
+    "modal.learn.title": "¡Sube de nivel!",
     "modal.learn.instructions":
-      "Danos unos segundos para crear notas rápidas de la lección.",
+      "🎮 ¡Prepárate! Estamos forjando tus **notas de misión**. Los conceptos clave brillarán para ganar **XP** extra!",
     "modal.feedback.title": "Enviar comentarios",
     "modal.feedback.contactLabel": "Contacto",
     "modal.feedback.contactPlaceholder": "Ingrese su información de contacto",
@@ -4203,9 +4203,9 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Learn",
+    "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "Give us a few seconds to create quick lesson notes.",
+      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -5801,9 +5801,9 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Learn",
+    "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "Give us a few seconds to create quick lesson notes.",
+      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -7399,9 +7399,9 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Learn",
+    "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "Give us a few seconds to create quick lesson notes.",
+      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -8995,9 +8995,9 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Learn",
+    "modal.learn.title": "Level Up!",
     "modal.learn.instructions":
-      "Give us a few seconds to create quick lesson notes.",
+      "🎮 Gear up! We're forging your **quest notes**. Key concepts will shine for extra **XP**!",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -1040,7 +1040,7 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Level Up!",
+    "modal.learn.title": "Learn",
     "modal.learn.instructions":
       "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
@@ -2785,7 +2785,7 @@ Las Estructuras de Datos y Algoritmos es una materia que a menudo intimida a los
     "modal.openSocialWallet.instructions":
       "¡No olvides tus claves antes de irte!",
     "modal.openSocialWallet.startButton": "Ir a la Billetera Social",
-    "modal.learn.title": "¡Sube de nivel!",
+    "modal.learn.title": "Aprender",
     "modal.learn.instructions":
       "🛡️ ¡Prepárate, héroe! Tu **registro de misión** se está cargando con colores épicos. Observa cómo los hechizos clave brillan con tonos **legendarios** para obtener **XP** extra!",
     "modal.feedback.title": "Enviar comentarios",
@@ -4203,7 +4203,7 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Level Up!",
+    "modal.learn.title": "Learn",
     "modal.learn.instructions":
       "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
@@ -5801,7 +5801,7 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Level Up!",
+    "modal.learn.title": "Learn",
     "modal.learn.instructions":
       "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
@@ -7399,7 +7399,7 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Level Up!",
+    "modal.learn.title": "Learn",
     "modal.learn.instructions":
       "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",
@@ -8995,7 +8995,7 @@ reverse(head) {
     "modal.openSocialWallet.instructions":
       "Don't forget your keys before leaving!",
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
-    "modal.learn.title": "Level Up!",
+    "modal.learn.title": "Learn",
     "modal.learn.instructions":
       "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
     "modal.feedback.title": "Submit Feedback",

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -1042,7 +1042,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Learn",
     "modal.learn.instructions":
-      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
+      "Give us a few seconds to generate notes based on your progress.",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -2787,7 +2787,7 @@ Las Estructuras de Datos y Algoritmos es una materia que a menudo intimida a los
     "modal.openSocialWallet.startButton": "Ir a la Billetera Social",
     "modal.learn.title": "Aprender",
     "modal.learn.instructions":
-      "🛡️ ¡Prepárate, héroe! Tu **registro de misión** se está cargando con colores épicos. Observa cómo los hechizos clave brillan con tonos **legendarios** para obtener **XP** extra!",
+      "Danos unos segundos para generar notas basadas en tu progreso.",
     "modal.feedback.title": "Enviar comentarios",
     "modal.feedback.contactLabel": "Contacto",
     "modal.feedback.contactPlaceholder": "Ingrese su información de contacto",
@@ -4205,7 +4205,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Learn",
     "modal.learn.instructions":
-      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
+      "Give us a few seconds to generate notes based on your progress.",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -5803,7 +5803,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Learn",
     "modal.learn.instructions":
-      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
+      "Give us a few seconds to generate notes based on your progress.",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -7401,7 +7401,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Learn",
     "modal.learn.instructions":
-      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
+      "Give us a few seconds to generate notes based on your progress.",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",
@@ -8997,7 +8997,7 @@ reverse(head) {
     "modal.openSocialWallet.startButton": "Go To Social Wallet",
     "modal.learn.title": "Learn",
     "modal.learn.instructions":
-      "🛡️ Ready up, hero! Your **quest log** is loading in epic colors. Watch key spells glow with **legendary** hues for bonus **XP**!",
+      "Give us a few seconds to generate notes based on your progress.",
     "modal.feedback.title": "Submit Feedback",
     "modal.feedback.contactLabel": "Contact",
     "modal.feedback.contactPlaceholder": "Enter your contact info",


### PR DESCRIPTION
## Summary
- Gamified the learn modal with a lively "Level Up!" title and quest-style instructions that spotlight key concepts.
- Highlighted bold Markdown in the learn modal by styling `<strong>` elements with a vibrant background.
- Rendered pre-lesson instructions via Markdown so highlighted concepts glow before content loads.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ddfa7bba88326b9a54fe3a98663dd