### PR TITLE
Enhance transition with animated progress and salary

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default [
+  {
+    ignores: ["dist", ".eslintrc.cjs"],
+    files: ["**/*.{js,jsx}"],
+    languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+    plugins: {
+      react,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    settings: { react: { version: "18.2" } },
+    rules: {
+      "react/jsx-no-target-blank": "off",
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+    },
+  },
+];

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3191,7 +3191,7 @@ const Step = ({
                   </Button>
                   &nbsp;&nbsp; &nbsp;&nbsp;
                   <Button
-                    onMouseDown={handleNextClick}
+                    onClick={handleNextClick}
                     mb={4}
                     boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
                     onKeyDown={(e) => {
@@ -3502,7 +3502,7 @@ const Step = ({
                     <Button
                       background="white"
                       variant={"outline"}
-                      onMouseDown={handleNextClick}
+                      onClick={handleNextClick}
                       mb={4}
                       boxShadow={"0.5px 0.5px 1px 0px black"}
                       onKeyDown={(e) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,6 @@ import {
   AccordionPanel,
   AccordionIcon,
   UnorderedList,
-  CircularProgress,
   Select,
   MenuButton,
   Menu,
@@ -2270,10 +2269,18 @@ const Step = ({
     const totalSteps = steps[userLanguage].length;
     const stepProgress = ((currentStep + 1) / totalSteps) * 100;
     const salaryText = loot[currentStep][userLanguage];
+    const dailyGoalPercent = Math.min(
+      (dailyProgress / (dailyGoals || 5)) * 100,
+      100
+    );
     setTransitionStats({
       salary: salaryVal,
       salaryProgress,
       stepProgress,
+      dailyGoalProgress: dailyGoalPercent,
+      dailyProgress: Math.min(dailyProgress, dailyGoals || 5),
+      dailyGoals: dailyGoals || 5,
+      dailyGoalLabel: translation[userLanguage]["dailyGoal"],
       message: salaryText,
     });
 
@@ -3410,44 +3417,6 @@ const Step = ({
                     transition="0.2s all ease-in-out"
                     borderBottomRightRadius={"0px"}
                   >
-                    {isCorrect ? (
-                      <VStack spacing={1} align="center" mb={2}>
-                        <Text
-                          fontSize="md"
-                          color="orange.500"
-                          fontWeight="bold"
-                        >
-                          {translation[userLanguage]["dailyGoal"]}:{" "}
-                          {dailyProgress + 1 > dailyGoals
-                            ? dailyGoals
-                            : dailyProgress + 1}{" "}
-                          / {dailyGoals || 5}{" "}
-                          {translation[userLanguage]["questions"]}
-                        </Text>
-
-                        <CircularProgress
-                          trackColor="#bfb49b"
-                          color="#82EBAC"
-                          value={
-                            ((dailyProgress + 1) / (dailyGoals || 5)) * 100
-                          }
-                          size={8}
-                        />
-
-                        {dailyProgress + 1 > dailyGoals ||
-                        dailyProgress + 1 === dailyGoals ? (
-                          <Text
-                            fontSize="md"
-                            color="orange.500"
-                            fontWeight="bold"
-                            mb={2}
-                          >
-                            {/* {translation[userLanguage]["celebrateMessage"]} */}
-                            {celebrationMessage}
-                          </Text>
-                        ) : null}
-                      </VStack>
-                    ) : null}
                     <Text
                       textAlign={"left"}
                       color={isCorrect ? "orange.500" : "red.500"}
@@ -3461,7 +3430,12 @@ const Step = ({
                           }
                         />
                       ) : null}
-                    </Text>{" "}
+                    </Text>
+                    {isCorrect && celebrationMessage && (
+                      <Text mt={2} fontSize="sm" color="orange.400">
+                        {celebrationMessage}
+                      </Text>
+                    )}
                   </Box>
                 </RiseUpAnimation>
               )}{" "}
@@ -5106,6 +5080,10 @@ function App({ isShutDown }) {
     salary: 0,
     salaryProgress: 0,
     stepProgress: 0,
+    dailyGoalProgress: 0,
+    dailyProgress: 0,
+    dailyGoals: 0,
+    dailyGoalLabel: "",
     message: "",
   });
 
@@ -5119,6 +5097,10 @@ function App({ isShutDown }) {
           salary: 0,
           salaryProgress: 0,
           stepProgress: 0,
+          dailyGoalProgress: 0,
+          dailyProgress: 0,
+          dailyGoals: 0,
+          dailyGoalLabel: "",
           message: "",
         });
       }, 800);
@@ -5385,6 +5367,10 @@ function App({ isShutDown }) {
         salary={transitionStats.salary}
         salaryProgress={transitionStats.salaryProgress}
         stepProgress={transitionStats.stepProgress}
+        dailyGoalProgress={transitionStats.dailyGoalProgress}
+        dailyProgress={transitionStats.dailyProgress}
+        dailyGoals={transitionStats.dailyGoals}
+        dailyGoalLabel={transitionStats.dailyGoalLabel}
         message={transitionStats.message}
       />
       {alert.isOpen && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5087,7 +5087,9 @@ function App({ isShutDown }) {
   const navigateWithTransition = (path, nextStep = null) => {
     setPendingPath(path);
     setPendingStep(nextStep);
-    setShowClouds(true);
+    // Defer showing the overlay to avoid the original click
+    // event immediately triggering the continue button
+    setTimeout(() => setShowClouds(true), 50);
   };
 
   const handleTransitionContinue = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5100,20 +5100,25 @@ function App({ isShutDown }) {
       setCurrentStep(pendingStep);
     }
     setShowClouds(false);
-    setTransitionStats({
-      salary: 0,
-      salaryProgress: 0,
-      stepProgress: 0,
-      dailyGoalProgress: 0,
-      dailyProgress: 0,
-      dailyGoals: 0,
-      dailyGoalLabel: "",
-      message: "",
-      detail: "",
-    });
     setPendingPath(null);
     setPendingStep(null);
   };
+
+  useEffect(() => {
+    if (!showClouds) {
+      setTransitionStats({
+        salary: 0,
+        salaryProgress: 0,
+        stepProgress: 0,
+        dailyGoalProgress: 0,
+        dailyProgress: 0,
+        dailyGoals: 0,
+        dailyGoalLabel: "",
+        message: "",
+        detail: "",
+      });
+    }
+  }, [showClouds]);
 
   // const {
   //   generateNostrKeys,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2267,10 +2267,13 @@ const Step = ({
     setEducationalContent([]);
     const salaryVal = loot[currentStep]["monetaryValue"] || 0;
     const salaryProgress = (salaryVal / 120000) * 100;
+    const totalSteps = steps[userLanguage].length;
+    const stepProgress = ((currentStep + 1) / totalSteps) * 100;
     const salaryText = loot[currentStep][userLanguage];
     setTransitionStats({
       salary: salaryVal,
-      progress: salaryProgress,
+      salaryProgress,
+      stepProgress,
       message: salaryText,
     });
 
@@ -5101,7 +5104,8 @@ function App({ isShutDown }) {
   const [showClouds, setShowClouds] = useState(false);
   const [transitionStats, setTransitionStats] = useState({
     salary: 0,
-    progress: 0,
+    salaryProgress: 0,
+    stepProgress: 0,
     message: "",
   });
 
@@ -5111,7 +5115,12 @@ function App({ isShutDown }) {
       navigate(path);
       setTimeout(() => {
         setShowClouds(false);
-        setTransitionStats({ salary: 0, progress: 0, message: "" });
+        setTransitionStats({
+          salary: 0,
+          salaryProgress: 0,
+          stepProgress: 0,
+          message: "",
+        });
       }, 800);
     }, 400);
   };
@@ -5374,7 +5383,8 @@ function App({ isShutDown }) {
       <CloudTransition
         isActive={showClouds}
         salary={transitionStats.salary}
-        progress={transitionStats.progress}
+        salaryProgress={transitionStats.salaryProgress}
+        stepProgress={transitionStats.stepProgress}
         message={transitionStats.message}
       />
       {alert.isOpen && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2264,6 +2264,15 @@ const Step = ({
     resetSuggestionMessages();
     resetEducationalMessages();
     setEducationalContent([]);
+    const salaryVal = loot[currentStep]["monetaryValue"] || 0;
+    const salaryProgress = (salaryVal / 120000) * 100;
+    const salaryText = loot[currentStep][userLanguage];
+    setTransitionStats({
+      salary: salaryVal,
+      progress: salaryProgress,
+      message: salaryText,
+    });
+
     //
     if (currentStep === 9) {
       const npub = localStorage.getItem("local_npub");
@@ -3439,42 +3448,6 @@ const Step = ({
                       textAlign={"left"}
                       color={isCorrect ? "orange.500" : "red.500"}
                     >
-                      {userLanguage !== "compsci-en" && isCorrect ? (
-                        <Box
-                          color={"orange.500"}
-                          mt={4}
-                          display="flex"
-                          flexDirection={"column"}
-                          alignItems={"center"}
-                        >
-                          <Text
-                            fontSize={"md"}
-                            color="green.400"
-                            fontWeight={"bold"}
-                          >
-                            {translation[userLanguage]["skillValue"]}$
-                            {loot[currentStep]["monetaryValue"]}/
-                            {translation[userLanguage]["year"]}
-                          </Text>
-                          <Progress
-                            width="50%"
-                            value={
-                              (loot[currentStep]["monetaryValue"] / 120000) *
-                              100
-                            }
-                            colorScheme="green"
-                            borderRadius="4px"
-                            border="1px solid #ececec"
-                            // boxShadow="0px 0px 0.5px 2px #ececec"
-                            boxShadow="0.5px 0.5px 1px 0px rgba(0,0,0,0.75)"
-                            mb={3}
-                          />
-                          <Text fontSize={"sm"}>
-                            {loot[currentStep][userLanguage]}
-                          </Text>
-                          <br />
-                        </Box>
-                      ) : null}
                       {feedback}{" "}
                       {grade ? (
                         <DataTags
@@ -5125,12 +5098,20 @@ function App({ isShutDown }) {
   const [allowPosts, setAllowPosts] = useState(false);
 
   const [showClouds, setShowClouds] = useState(false);
+  const [transitionStats, setTransitionStats] = useState({
+    salary: 0,
+    progress: 0,
+    message: "",
+  });
 
   const navigateWithTransition = (path) => {
     setShowClouds(true);
     setTimeout(() => {
       navigate(path);
-      setTimeout(() => setShowClouds(false), 800);
+      setTimeout(() => {
+        setShowClouds(false);
+        setTransitionStats({ salary: 0, progress: 0, message: "" });
+      }, 800);
     }, 400);
   };
 
@@ -5389,7 +5370,12 @@ function App({ isShutDown }) {
 
   return (
     <Box ref={topRef}>
-      <CloudTransition isActive={showClouds} />
+      <CloudTransition
+        isActive={showClouds}
+        salary={transitionStats.salary}
+        progress={transitionStats.progress}
+        message={transitionStats.message}
+      />
       {alert.isOpen && (
         <Alert
           status={alert.status}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5076,6 +5076,7 @@ function App({ isShutDown }) {
   const [allowPosts, setAllowPosts] = useState(false);
 
   const [showClouds, setShowClouds] = useState(false);
+  const [pendingPath, setPendingPath] = useState(null);
   const [transitionStats, setTransitionStats] = useState({
     salary: 0,
     salaryProgress: 0,
@@ -5088,23 +5089,26 @@ function App({ isShutDown }) {
   });
 
   const navigateWithTransition = (path) => {
+    setPendingPath(path);
     setShowClouds(true);
-    setTimeout(() => {
-      navigate(path);
-      setTimeout(() => {
-        setShowClouds(false);
-        setTransitionStats({
-          salary: 0,
-          salaryProgress: 0,
-          stepProgress: 0,
-          dailyGoalProgress: 0,
-          dailyProgress: 0,
-          dailyGoals: 0,
-          dailyGoalLabel: "",
-          message: "",
-        });
-      }, 800);
-    }, 400);
+  };
+
+  const handleTransitionContinue = () => {
+    if (pendingPath) {
+      navigate(pendingPath);
+    }
+    setShowClouds(false);
+    setTransitionStats({
+      salary: 0,
+      salaryProgress: 0,
+      stepProgress: 0,
+      dailyGoalProgress: 0,
+      dailyProgress: 0,
+      dailyGoals: 0,
+      dailyGoalLabel: "",
+      message: "",
+    });
+    setPendingPath(null);
   };
 
   // const {
@@ -5372,6 +5376,7 @@ function App({ isShutDown }) {
         dailyGoals={transitionStats.dailyGoals}
         dailyGoalLabel={transitionStats.dailyGoalLabel}
         message={transitionStats.message}
+        onContinue={handleTransitionContinue}
       />
       {alert.isOpen && (
         <Alert

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1347,6 +1347,7 @@ const Step = ({
   hasSubmittedPasscode,
   setCurrentStep,
   navigateWithTransition,
+  setTransitionStats,
 }) => {
   let loot = buildSuperLoot();
 
@@ -5493,6 +5494,7 @@ function App({ isShutDown }) {
                       hasSubmittedPasscode={hasSubmittedPasscode}
                       setCurrentStep={setCurrentStep}
                       navigateWithTransition={navigateWithTransition}
+                      setTransitionStats={setTransitionStats}
                     />
                   </PrivateRoute>
                 }

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -17,6 +17,10 @@ const CloudTransition = ({
   salary,
   salaryProgress,
   stepProgress,
+  dailyGoalProgress,
+  dailyProgress,
+  dailyGoals,
+  dailyGoalLabel,
   message,
 }) => {
   const canvasRef = useRef(null);
@@ -101,6 +105,9 @@ const CloudTransition = ({
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
         >
           <Box
             as="canvas"
@@ -115,73 +122,97 @@ const CloudTransition = ({
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
-            position="absolute"
-            top="50%"
-            left="50%"
-            transform="translate(-50%, -50%)"
             textAlign="center"
             color="purple.600"
+            w="90%"
+            maxW="400px"
           >
-            <>
+            <Text
+              as={motion.p}
+              fontSize="3xl"
+              fontWeight="bold"
+              mb={4}
+              initial={{ scale: 0.9 }}
+              animate={{ scale: 1 }}
+              transition={{ duration: 0.6 }}
+            >
+              +${salary}/yr
+            </Text>
+            <Box w="100%" mx="auto" mb={6}>
+              <Text fontSize="sm" mb={1} color="purple.500">
+                Salary
+              </Text>
+              <Box
+                h="8px"
+                bg="whiteAlpha.600"
+                borderRadius="full"
+                overflow="hidden"
+              >
+                <motion.div
+                  initial={{ width: 0 }}
+                  animate={{ width: `${salaryProgress}%` }}
+                  transition={{ duration: 1.2 }}
+                  style={{
+                    height: "100%",
+                    background: "linear-gradient(90deg,#FFDEE9,#B5FFFC)",
+                  }}
+                />
+              </Box>
+            </Box>
+            <Box w="100%" mx="auto" mb={6}>
+              <Text fontSize="sm" mb={1} color="purple.500">
+                Progress
+              </Text>
+              <Box
+                h="8px"
+                bg="whiteAlpha.600"
+                borderRadius="full"
+                overflow="hidden"
+              >
+                <motion.div
+                  initial={{ width: 0 }}
+                  animate={{ width: `${stepProgress}%` }}
+                  transition={{ duration: 1.2, delay: 0.2 }}
+                  style={{
+                    height: "100%",
+                    background: "linear-gradient(90deg,#C3E4FD,#EFD3FF)",
+                  }}
+                />
+              </Box>
+            </Box>
+            <Box w="100%" mx="auto">
+              <Text fontSize="sm" mb={1} color="purple.500">
+                {dailyGoalLabel} {dailyProgress}/{dailyGoals}
+              </Text>
+              <Box
+                h="8px"
+                bg="whiteAlpha.600"
+                borderRadius="full"
+                overflow="hidden"
+              >
+                <motion.div
+                  initial={{ width: 0 }}
+                  animate={{ width: `${dailyGoalProgress}%` }}
+                  transition={{ duration: 1.2, delay: 0.4 }}
+                  style={{
+                    height: "100%",
+                    background: "linear-gradient(90deg,#FFFBCC,#D5F0FF)",
+                  }}
+                />
+              </Box>
+            </Box>
+            {message && (
               <Text
                 as={motion.p}
-                fontSize="3xl"
-                fontWeight="bold"
-                mb={4}
-                initial={{ scale: 0.8 }}
-                animate={{ scale: 1 }}
-                transition={{ duration: 0.6 }}
+                fontSize="md"
+                mt={6}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 0.8, y: 0 }}
+                transition={{ duration: 0.8, delay: 0.6 }}
               >
-                +${salary}/yr
+                {message}
               </Text>
-              <Box w="60%" mx="auto" mb={6}>
-                <Text fontSize="sm" mb={1} color="purple.500">
-                  Salary
-                </Text>
-                <Box
-                  h="8px"
-                  bg="whiteAlpha.600"
-                  borderRadius="full"
-                  overflow="hidden"
-                >
-                  <motion.div
-                    initial={{ width: 0 }}
-                    animate={{ width: `${salaryProgress}%` }}
-                    transition={{ duration: 1.2 }}
-                    style={{
-                      height: "100%",
-                      background: "linear-gradient(90deg,#FFDEE9,#B5FFFC)",
-                    }}
-                  />
-                </Box>
-              </Box>
-              <Box w="60%" mx="auto">
-                <Text fontSize="sm" mb={1} color="purple.500">
-                  Progress
-                </Text>
-                <Box
-                  h="8px"
-                  bg="whiteAlpha.600"
-                  borderRadius="full"
-                  overflow="hidden"
-                >
-                  <motion.div
-                    initial={{ width: 0 }}
-                    animate={{ width: `${stepProgress}%` }}
-                    transition={{ duration: 1.2, delay: 0.2 }}
-                    style={{
-                      height: "100%",
-                      background: "linear-gradient(90deg,#C3E4FD,#EFD3FF)",
-                    }}
-                  />
-                </Box>
-              </Box>
-              {message && (
-                <Text fontSize="md" mt={6}>
-                  {message}
-                </Text>
-              )}
-            </>
+            )}
           </MotionBox>
         </Box>
       )}

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -22,6 +22,7 @@ const CloudTransition = ({
   dailyGoals,
   dailyGoalLabel,
   message,
+  detail,
   onContinue,
 }) => {
   const canvasRef = useRef(null);
@@ -212,6 +213,18 @@ const CloudTransition = ({
                 transition={{ duration: 0.8, delay: 0.6 }}
               >
                 {message}
+              </Text>
+            )}
+            {detail && (
+              <Text
+                as={motion.p}
+                fontSize="sm"
+                mt={2}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 0.8, y: 0 }}
+                transition={{ duration: 0.8, delay: 0.7 }}
+              >
+                {detail}
               </Text>
             )}
             <Button

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -3,14 +3,16 @@ import { Box, Text } from "@chakra-ui/react";
 import { motion, AnimatePresence } from "framer-motion";
 
 const colors = [
-  "rgba(255,215,0,0.6)", // gold
-  "rgba(255,105,180,0.6)", // pink
-  "rgba(186,85,211,0.6)", // purple
-  "rgba(255,165,0,0.6)", // orange
-  "rgba(255,140,0,0.6)", // sunset orange
+  "rgba(255,255,255,0.8)", // soft white
+  "rgba(224,240,255,0.6)", // powder blue
+  "rgba(245,224,255,0.6)", // lavender
+  "rgba(255,240,245,0.6)", // pink blush
+  "rgba(255,255,224,0.6)", // light gold
 ];
 
-const CloudTransition = ({ isActive }) => {
+const MotionBox = motion(Box);
+
+const CloudTransition = ({ isActive, salary, progress, message }) => {
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -23,26 +25,19 @@ const CloudTransition = ({ isActive }) => {
     let width = (canvas.width = window.innerWidth);
     let height = (canvas.height = window.innerHeight);
 
-    // Larger cloud blobs
-    const clouds = Array.from({ length: 25 }, () => ({
+    const clouds = Array.from({ length: 20 }, () => ({
       x: Math.random() * width,
       y: Math.random() * height,
-      radius: 60 + Math.random() * 120,
-      speed: 0.5 + Math.random() * 0.5,
-      color: colors[Math.floor(Math.random() * colors.length)],
-    }));
-
-    // Smaller noisy wisps to add more visual texture
-    const noise = Array.from({ length: 80 }, () => ({
-      x: Math.random() * width,
-      y: Math.random() * height,
-      radius: 10 + Math.random() * 20,
-      speed: 0.3 + Math.random() * 0.7,
+      radius: 80 + Math.random() * 140,
+      speed: 0.2 + Math.random() * 0.3,
       color: colors[Math.floor(Math.random() * colors.length)],
     }));
 
     const draw = () => {
-      ctx.fillStyle = "#FFFFFF";
+      const sky = ctx.createLinearGradient(0, 0, 0, height);
+      sky.addColorStop(0, "#e3f2fd");
+      sky.addColorStop(1, "#ffffff");
+      ctx.fillStyle = sky;
       ctx.fillRect(0, 0, width, height);
 
       clouds.forEach((cloud) => {
@@ -65,30 +60,6 @@ const CloudTransition = ({ isActive }) => {
         if (cloud.y + cloud.radius < 0) {
           cloud.y = height + cloud.radius;
           cloud.x = Math.random() * width;
-        }
-      });
-
-      // Draw noisy wisps
-      noise.forEach((wisp) => {
-        const grad = ctx.createRadialGradient(
-          wisp.x,
-          wisp.y,
-          0,
-          wisp.x,
-          wisp.y,
-          wisp.radius
-        );
-        grad.addColorStop(0, wisp.color);
-        grad.addColorStop(1, "rgba(255,255,255,0)");
-        ctx.fillStyle = grad;
-        ctx.beginPath();
-        ctx.arc(wisp.x, wisp.y, wisp.radius, 0, Math.PI * 2);
-        ctx.fill();
-
-        wisp.y -= wisp.speed;
-        if (wisp.y + wisp.radius < 0) {
-          wisp.y = height + wisp.radius;
-          wisp.x = Math.random() * width;
         }
       });
 
@@ -134,18 +105,56 @@ const CloudTransition = ({ isActive }) => {
             w="100%"
             h="100%"
           />
-          <Text
+          <MotionBox
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
             position="absolute"
             top="50%"
             left="50%"
             transform="translate(-50%, -50%)"
-            fontSize="4xl"
-            fontWeight="bold"
+            textAlign="center"
             color="purple.600"
-            textShadow="0 0 10px rgba(255,215,0,0.8)"
           >
-            Level Up!
-          </Text>
+            {salary ? (
+              <>
+                <Text fontSize="3xl" fontWeight="bold" mb={4}>
+                  +${salary}/yr
+                </Text>
+                <Box
+                  w="60%"
+                  h="8px"
+                  bg="whiteAlpha.600"
+                  borderRadius="full"
+                  overflow="hidden"
+                  mx="auto"
+                >
+                  <motion.div
+                    initial={{ width: 0 }}
+                    animate={{ width: `${progress}%` }}
+                    transition={{ duration: 1.2 }}
+                    style={{
+                      height: "100%",
+                      background: "linear-gradient(90deg,#FFDEE9,#B5FFFC)",
+                    }}
+                  />
+                </Box>
+                {message && (
+                  <Text fontSize="md" mt={4}>
+                    {message}
+                  </Text>
+                )}
+              </>
+            ) : (
+              <Text
+                fontSize="4xl"
+                fontWeight="bold"
+                textShadow="0 0 10px rgba(255,255,255,0.8)"
+              >
+                Level Up!
+              </Text>
+            )}
+          </MotionBox>
         </Box>
       )}
     </AnimatePresence>

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Box, Text, Button } from "@chakra-ui/react";
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -26,6 +26,19 @@ const CloudTransition = ({
   onContinue,
 }) => {
   const canvasRef = useRef(null);
+  const [canContinue, setCanContinue] = useState(false);
+
+  // Prevent the click that opens the overlay from immediately
+  // triggering the Continue action by enabling the button only
+  // after a short delay
+  useEffect(() => {
+    if (isActive) {
+      setCanContinue(false);
+      const id = setTimeout(() => setCanContinue(true), 200);
+      return () => clearTimeout(id);
+    }
+    setCanContinue(false);
+  }, [isActive]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -238,6 +251,7 @@ const CloudTransition = ({
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.8 }}
               onClick={onContinue}
+              disabled={!canContinue}
             >
               Continue
             </Button>

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -12,7 +12,13 @@ const colors = [
 
 const MotionBox = motion(Box);
 
-const CloudTransition = ({ isActive, salary, progress, message }) => {
+const CloudTransition = ({
+  isActive,
+  salary,
+  salaryProgress,
+  stepProgress,
+  message,
+}) => {
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -116,22 +122,31 @@ const CloudTransition = ({ isActive, salary, progress, message }) => {
             textAlign="center"
             color="purple.600"
           >
-            {salary ? (
-              <>
-                <Text fontSize="3xl" fontWeight="bold" mb={4}>
-                  +${salary}/yr
+            <>
+              <Text
+                as={motion.p}
+                fontSize="3xl"
+                fontWeight="bold"
+                mb={4}
+                initial={{ scale: 0.8 }}
+                animate={{ scale: 1 }}
+                transition={{ duration: 0.6 }}
+              >
+                +${salary}/yr
+              </Text>
+              <Box w="60%" mx="auto" mb={6}>
+                <Text fontSize="sm" mb={1} color="purple.500">
+                  Salary
                 </Text>
                 <Box
-                  w="60%"
                   h="8px"
                   bg="whiteAlpha.600"
                   borderRadius="full"
                   overflow="hidden"
-                  mx="auto"
                 >
                   <motion.div
                     initial={{ width: 0 }}
-                    animate={{ width: `${progress}%` }}
+                    animate={{ width: `${salaryProgress}%` }}
                     transition={{ duration: 1.2 }}
                     style={{
                       height: "100%",
@@ -139,21 +154,34 @@ const CloudTransition = ({ isActive, salary, progress, message }) => {
                     }}
                   />
                 </Box>
-                {message && (
-                  <Text fontSize="md" mt={4}>
-                    {message}
-                  </Text>
-                )}
-              </>
-            ) : (
-              <Text
-                fontSize="4xl"
-                fontWeight="bold"
-                textShadow="0 0 10px rgba(255,255,255,0.8)"
-              >
-                Level Up!
-              </Text>
-            )}
+              </Box>
+              <Box w="60%" mx="auto">
+                <Text fontSize="sm" mb={1} color="purple.500">
+                  Progress
+                </Text>
+                <Box
+                  h="8px"
+                  bg="whiteAlpha.600"
+                  borderRadius="full"
+                  overflow="hidden"
+                >
+                  <motion.div
+                    initial={{ width: 0 }}
+                    animate={{ width: `${stepProgress}%` }}
+                    transition={{ duration: 1.2, delay: 0.2 }}
+                    style={{
+                      height: "100%",
+                      background: "linear-gradient(90deg,#C3E4FD,#EFD3FF)",
+                    }}
+                  />
+                </Box>
+              </Box>
+              {message && (
+                <Text fontSize="md" mt={6}>
+                  {message}
+                </Text>
+              )}
+            </>
           </MotionBox>
         </Box>
       )}

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Text, Button } from "@chakra-ui/react";
 import { motion, AnimatePresence } from "framer-motion";
 
 const colors = [
@@ -22,6 +22,7 @@ const CloudTransition = ({
   dailyGoals,
   dailyGoalLabel,
   message,
+  onContinue,
 }) => {
   const canvasRef = useRef(null);
 
@@ -213,6 +214,20 @@ const CloudTransition = ({
                 {message}
               </Text>
             )}
+            <Button
+              as={motion.button}
+              mt={8}
+              colorScheme="purple"
+              variant="outline"
+              borderRadius="full"
+              px={6}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: 0.8 }}
+              onClick={onContinue}
+            >
+              Continue
+            </Button>
           </MotionBox>
         </Box>
       )}


### PR DESCRIPTION
## Summary
- Replace colorful CloudTransition with airy, pastel animation evoking a gentle zephyr
- Show salary progress and description in the transition overlay and remove from answer bubble
- Track transition stats in App and reset after navigation

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_689577e17fc083268c01108155c03e1a