### PR TITLE
Fix disappearing stats in transition view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5086,8 +5086,13 @@ function App({ isShutDown }) {
   const [transitionStats, setTransitionStats] = useState(
     defaultTransitionStats
   );
+  const resetStatsTimeoutRef = useRef(null);
 
   const navigateWithTransition = (path, nextStep = null) => {
+    if (resetStatsTimeoutRef.current) {
+      clearTimeout(resetStatsTimeoutRef.current);
+      resetStatsTimeoutRef.current = null;
+    }
     setPendingPath(path);
     setPendingStep(nextStep);
     // Defer showing the overlay to avoid the original click
@@ -5105,14 +5110,14 @@ function App({ isShutDown }) {
     setShowClouds(false);
     setPendingPath(null);
     setPendingStep(null);
-  };
-
-  useEffect(() => {
-    if (!showClouds) {
-      const id = setTimeout(() => setTransitionStats(defaultTransitionStats), 1000);
-      return () => clearTimeout(id);
+    if (resetStatsTimeoutRef.current) {
+      clearTimeout(resetStatsTimeoutRef.current);
     }
-  }, [showClouds]);
+    resetStatsTimeoutRef.current = setTimeout(
+      () => setTransitionStats(defaultTransitionStats),
+      1000
+    );
+  };
 
   // const {
   //   generateNostrKeys,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5102,10 +5102,7 @@ function App({ isShutDown }) {
     setShowClouds(false);
     setPendingPath(null);
     setPendingStep(null);
-  };
-
-  useEffect(() => {
-    if (!showClouds) {
+    setTimeout(() => {
       setTransitionStats({
         salary: 0,
         salaryProgress: 0,
@@ -5117,8 +5114,8 @@ function App({ isShutDown }) {
         message: "",
         detail: "",
       });
-    }
-  }, [showClouds]);
+    }, 300);
+  };
 
   // const {
   //   generateNostrKeys,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5072,7 +5072,7 @@ function App({ isShutDown }) {
   const [showClouds, setShowClouds] = useState(false);
   const [pendingPath, setPendingPath] = useState(null);
   const [pendingStep, setPendingStep] = useState(null);
-  const [transitionStats, setTransitionStats] = useState({
+  const defaultTransitionStats = {
     salary: 0,
     salaryProgress: 0,
     stepProgress: 0,
@@ -5082,7 +5082,10 @@ function App({ isShutDown }) {
     dailyGoalLabel: "",
     message: "",
     detail: "",
-  });
+  };
+  const [transitionStats, setTransitionStats] = useState(
+    defaultTransitionStats
+  );
 
   const navigateWithTransition = (path, nextStep = null) => {
     setPendingPath(path);
@@ -5102,20 +5105,14 @@ function App({ isShutDown }) {
     setShowClouds(false);
     setPendingPath(null);
     setPendingStep(null);
-    setTimeout(() => {
-      setTransitionStats({
-        salary: 0,
-        salaryProgress: 0,
-        stepProgress: 0,
-        dailyGoalProgress: 0,
-        dailyProgress: 0,
-        dailyGoals: 0,
-        dailyGoalLabel: "",
-        message: "",
-        detail: "",
-      });
-    }, 300);
   };
+
+  useEffect(() => {
+    if (!showClouds) {
+      const id = setTimeout(() => setTransitionStats(defaultTransitionStats), 1000);
+      return () => clearTimeout(id);
+    }
+  }, [showClouds]);
 
   // const {
   //   generateNostrKeys,

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -142,80 +142,6 @@ const CloudTransition = ({
             w="90%"
             maxW="400px"
           >
-            <Text
-              as={motion.p}
-              fontSize="3xl"
-              fontWeight="bold"
-              mb={4}
-              initial={{ scale: 0.9 }}
-              animate={{ scale: 1 }}
-              transition={{ duration: 0.6 }}
-            >
-              +${salary}/yr
-            </Text>
-            <Box w="100%" mx="auto" mb={6}>
-              <Text fontSize="sm" mb={1} color="purple.500">
-                Salary
-              </Text>
-              <Box
-                h="8px"
-                bg="whiteAlpha.600"
-                borderRadius="full"
-                overflow="hidden"
-              >
-                <motion.div
-                  initial={{ width: 0 }}
-                  animate={{ width: `${salaryProgress}%` }}
-                  transition={{ duration: 1.2 }}
-                  style={{
-                    height: "100%",
-                    background: "linear-gradient(90deg,#FFDEE9,#B5FFFC)",
-                  }}
-                />
-              </Box>
-            </Box>
-            <Box w="100%" mx="auto" mb={6}>
-              <Text fontSize="sm" mb={1} color="purple.500">
-                Progress
-              </Text>
-              <Box
-                h="8px"
-                bg="whiteAlpha.600"
-                borderRadius="full"
-                overflow="hidden"
-              >
-                <motion.div
-                  initial={{ width: 0 }}
-                  animate={{ width: `${stepProgress}%` }}
-                  transition={{ duration: 1.2, delay: 0.2 }}
-                  style={{
-                    height: "100%",
-                    background: "linear-gradient(90deg,#C3E4FD,#EFD3FF)",
-                  }}
-                />
-              </Box>
-            </Box>
-            <Box w="100%" mx="auto">
-              <Text fontSize="sm" mb={1} color="purple.500">
-                {dailyGoalLabel} {dailyProgress}/{dailyGoals}
-              </Text>
-              <Box
-                h="8px"
-                bg="whiteAlpha.600"
-                borderRadius="full"
-                overflow="hidden"
-              >
-                <motion.div
-                  initial={{ width: 0 }}
-                  animate={{ width: `${dailyGoalProgress}%` }}
-                  transition={{ duration: 1.2, delay: 0.4 }}
-                  style={{
-                    height: "100%",
-                    background: "linear-gradient(90deg,#FFFBCC,#D5F0FF)",
-                  }}
-                />
-              </Box>
-            </Box>
             {message && (
               <Text
                 as={motion.p}
@@ -225,21 +151,101 @@ const CloudTransition = ({
                 animate={{ opacity: 0.8, y: 0 }}
                 transition={{ duration: 0.8, delay: 0.6 }}
               >
+                <Text
+                  as={motion.p}
+                  fontSize="3xl"
+                  fontWeight="bold"
+                  mb={4}
+                  initial={{ scale: 0.9 }}
+                  animate={{ scale: 1 }}
+                  transition={{ duration: 0.6 }}
+                >
+                  +${salary}/yr
+                </Text>
+                {detail && (
+                  <Text
+                    as={motion.p}
+                    fontSize="sm"
+                    mt={2}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 0.8, y: 0 }}
+                    transition={{ duration: 0.8, delay: 0.7 }}
+                  >
+                    {detail}
+                  </Text>
+                )}
+                <br />
+                <br />
+                <Box w="100%" mx="auto" mb={6}>
+                  <Text fontSize="sm" mb={1} color="purple.500">
+                    Salary
+                  </Text>
+                  <Box
+                    h="8px"
+                    bg="whiteAlpha.600"
+                    borderRadius="full"
+                    overflow="hidden"
+                  >
+                    <motion.div
+                      initial={{ width: 0 }}
+                      animate={{ width: `${salaryProgress}%` }}
+                      transition={{ duration: 1.2 }}
+                      style={{
+                        height: "100%",
+                        background: "linear-gradient(90deg,#FFDEE9,#B5FFFC)",
+                      }}
+                    />
+                  </Box>
+                </Box>
+                <Box w="100%" mx="auto" mb={6}>
+                  <Text fontSize="sm" mb={1} color="purple.500">
+                    Progress
+                  </Text>
+                  <Box
+                    h="8px"
+                    bg="whiteAlpha.600"
+                    borderRadius="full"
+                    overflow="hidden"
+                  >
+                    <motion.div
+                      initial={{ width: 0 }}
+                      animate={{ width: `${stepProgress}%` }}
+                      transition={{ duration: 1.2, delay: 0.2 }}
+                      style={{
+                        height: "100%",
+                        background: "linear-gradient(90deg,#C3E4FD,#EFD3FF)",
+                      }}
+                    />
+                  </Box>
+                </Box>
+                <Box w="100%" mx="auto">
+                  <Text fontSize="sm" mb={1} color="purple.500">
+                    {dailyGoalLabel} {dailyProgress}/{dailyGoals}
+                  </Text>
+                  <Box
+                    h="8px"
+                    bg="whiteAlpha.600"
+                    borderRadius="full"
+                    overflow="hidden"
+                    border="1px solid #ededed"
+                  >
+                    <motion.div
+                      initial={{ width: 0 }}
+                      animate={{ width: `${dailyGoalProgress}%` }}
+                      transition={{ duration: 1.2, delay: 0.4 }}
+                      style={{
+                        height: "100%",
+                        background: "linear-gradient(90deg,#FFFBCC,#D5F0FF)",
+                      }}
+                    />
+                  </Box>
+                </Box>
+                <br />
+                <br />
                 {message}
               </Text>
             )}
-            {detail && (
-              <Text
-                as={motion.p}
-                fontSize="sm"
-                mt={2}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 0.8, y: 0 }}
-                transition={{ duration: 0.8, delay: 0.7 }}
-              >
-                {detail}
-              </Text>
-            )}
+
             <Button
               as={motion.button}
               mt={8}
@@ -263,4 +269,3 @@ const CloudTransition = ({
 };
 
 export default CloudTransition;
-


### PR DESCRIPTION
## Summary
- keep CloudTransition stats until the overlay finishes exiting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_68959b3c4b788326b3383576b198953e