### PR TITLE
Refine transition and fix progress

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2264,22 +2264,40 @@ const Step = ({
     resetSuggestionMessages();
     resetEducationalMessages();
     setEducationalContent([]);
+    const nextStep = currentStep + 1;
+
+    if (currentStep === 0) {
+      setIsPostingWithNostr(true);
+      const npub = localStorage.getItem("local_npub");
+      try {
+        await incrementUserStep(npub, currentStep);
+      } finally {
+        setIsPostingWithNostr(false);
+      }
+      setCurrentStep(nextStep);
+      navigate(`/onboarding/${currentStep + 2}`);
+      return;
+    }
+
     const salaryVal = loot[currentStep]["monetaryValue"] || 0;
     const salaryProgress = (salaryVal / 120000) * 100;
     const totalSteps = steps[userLanguage].length;
     const stepProgress = ((currentStep + 1) / totalSteps) * 100;
     const salaryText = loot[currentStep][userLanguage];
+    const updatedDailyProgress = Math.min(
+      dailyProgress + 1,
+      dailyGoals || 5
+    );
     const dailyGoalPercent = Math.min(
-      (dailyProgress / (dailyGoals || 5)) * 100,
+      (updatedDailyProgress / (dailyGoals || 5)) * 100,
       100
     );
-    const nextStep = currentStep + 1;
     setTransitionStats({
       salary: salaryVal,
       salaryProgress,
       stepProgress,
       dailyGoalProgress: dailyGoalPercent,
-      dailyProgress: Math.min(dailyProgress, dailyGoals || 5),
+      dailyProgress: updatedDailyProgress,
       dailyGoals: dailyGoals || 5,
       dailyGoalLabel: translation[userLanguage]["dailyGoal"],
       message: celebrationMessage,

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -3,11 +3,11 @@ import { Box, Text, Button } from "@chakra-ui/react";
 import { motion, AnimatePresence } from "framer-motion";
 
 const colors = [
-  "rgba(255,255,255,0.8)", // soft white
-  "rgba(224,240,255,0.6)", // powder blue
-  "rgba(245,224,255,0.6)", // lavender
-  "rgba(255,240,245,0.6)", // pink blush
-  "rgba(255,255,224,0.6)", // light gold
+  "rgba(255,255,255,0.6)", // soft white
+  "rgba(224,240,255,0.4)", // powder blue
+  "rgba(245,224,255,0.4)", // lavender
+  "rgba(255,240,245,0.4)", // pink blush
+  "rgba(255,255,224,0.4)", // light gold
 ];
 
 const MotionBox = motion(Box);
@@ -50,11 +50,11 @@ const CloudTransition = ({
     let width = (canvas.width = window.innerWidth);
     let height = (canvas.height = window.innerHeight);
 
-    const clouds = Array.from({ length: 20 }, () => ({
+    const clouds = Array.from({ length: 10 }, () => ({
       x: Math.random() * width,
       y: Math.random() * height,
-      radius: 80 + Math.random() * 140,
-      speed: 0.2 + Math.random() * 0.3,
+      radius: 40 + Math.random() * 80,
+      speed: 0.4 + Math.random() * 0.4,
       color: colors[Math.floor(Math.random() * colors.length)],
     }));
 
@@ -136,7 +136,7 @@ const CloudTransition = ({
           <MotionBox
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
+            transition={{ duration: 0.4 }}
             textAlign="center"
             color="purple.600"
             w="90%"
@@ -149,7 +149,7 @@ const CloudTransition = ({
                 mt={6}
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 0.8, y: 0 }}
-                transition={{ duration: 0.8, delay: 0.6 }}
+                transition={{ duration: 0.4, delay: 0.2 }}
               >
                 <Text
                   as={motion.p}
@@ -169,7 +169,7 @@ const CloudTransition = ({
                     mt={2}
                     initial={{ opacity: 0, y: 10 }}
                     animate={{ opacity: 0.8, y: 0 }}
-                    transition={{ duration: 0.8, delay: 0.7 }}
+                    transition={{ duration: 0.4, delay: 0.3 }}
                   >
                     {detail}
                   </Text>
@@ -189,7 +189,7 @@ const CloudTransition = ({
                     <motion.div
                       initial={{ width: 0 }}
                       animate={{ width: `${salaryProgress}%` }}
-                      transition={{ duration: 1.2 }}
+                      transition={{ duration: 0.6 }}
                       style={{
                         height: "100%",
                         background: "linear-gradient(90deg,#FFDEE9,#B5FFFC)",
@@ -210,7 +210,7 @@ const CloudTransition = ({
                     <motion.div
                       initial={{ width: 0 }}
                       animate={{ width: `${stepProgress}%` }}
-                      transition={{ duration: 1.2, delay: 0.2 }}
+                      transition={{ duration: 0.6, delay: 0.1 }}
                       style={{
                         height: "100%",
                         background: "linear-gradient(90deg,#C3E4FD,#EFD3FF)",
@@ -232,7 +232,7 @@ const CloudTransition = ({
                     <motion.div
                       initial={{ width: 0 }}
                       animate={{ width: `${dailyGoalProgress}%` }}
-                      transition={{ duration: 1.2, delay: 0.4 }}
+                      transition={{ duration: 0.6, delay: 0.2 }}
                       style={{
                         height: "100%",
                         background: "linear-gradient(90deg,#FFFBCC,#D5F0FF)",
@@ -255,7 +255,7 @@ const CloudTransition = ({
               px={6}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.8 }}
+              transition={{ duration: 0.4, delay: 0.4 }}
               onClick={onContinue}
               disabled={!canContinue}
             >


### PR DESCRIPTION
## Summary
- Streamline the CloudTransition overlay with fewer, lighter clouds and quicker animations
- Skip transition scene when moving from intro question to first question
- Correct daily progress tracking in transition stats

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_6895a6af64b08326804ab5565e8037e1