### PR TITLE
feat: add onboarding drawer button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5407,7 +5407,6 @@ function App({ isShutDown }) {
           <OnboardingDrawer
             userLanguage={userLanguage}
             setUserLanguage={setUserLanguage}
-            setCurrentStep={setCurrentStep}
           />
         )}
 

--- a/src/Onboarding.jsx
+++ b/src/Onboarding.jsx
@@ -22,7 +22,6 @@ import {
   MenuItem,
   Menu,
 } from "@chakra-ui/react";
-import { useNavigate } from "react-router-dom";
 import { GiBullseye } from "react-icons/gi";
 import { TbBellHeart } from "react-icons/tb";
 
@@ -61,17 +60,14 @@ import { ChevronDownIcon } from "@chakra-ui/icons";
 export const Onboarding = ({
   userLanguage,
   setUserLanguage,
-  setCurrentStep,
   step,
   setStep,
-  onClose,
 }) => {
   const { assignExistingBadgeToNpub } = useSharedNostr(
     localStorage.getItem("local_npub"),
     localStorage.getItem("local_nsec")
   );
   const [interval, setInterval] = useState(2880);
-  const navigate = useNavigate();
   const toast = useToast();
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
 
@@ -86,23 +82,12 @@ export const Onboarding = ({
     assignExistingBadgeToNpub(
       onboardingTranscript["name"][userLanguage].replace(/ /g, "-")
     );
-
-    // navigate("/q/0");
-    if (onClose) {
-      onClose();
-    }
     onAwardModalOpen();
   };
 
   const handleActuallyReallySeriouslyLaunchApp = () => {
     setOnboardingToDone(localStorage.getItem("local_npub"), 5);
-
-    setCurrentStep(5);
     setStep("done");
-    if (onClose) {
-      onClose();
-    }
-    navigate("/q/5");
   };
 
   // Scroll to top on step change
@@ -313,11 +298,6 @@ export const Onboarding = ({
             moveToNext={() => {
               incrementUserOnboardingStep(localStorage.getItem("local_npub"));
               setStep("2");
-              setCurrentStep(0);
-              if (onClose) {
-                onClose();
-              }
-              navigate("/q/0");
             }}
           />
         </Box>
@@ -776,11 +756,6 @@ export const Onboarding = ({
                         localStorage.getItem("local_npub")
                       );
                       setStep("3");
-                      setCurrentStep(1);
-                      if (onClose) {
-                        onClose();
-                      }
-                      navigate("/q/1");
                     }}
                     boxShadow="0.5px 0.5px 1px 0px black"
                     mb={18}
@@ -863,7 +838,6 @@ export const Onboarding = ({
                     setInterval={setInterval}
                     userId={localStorage.getItem("local_npub")}
                     userLanguage={userLanguage}
-                    setCurrentStep={setCurrentStep}
                   />
                 </Box>
               </FadeInComponent>
@@ -1140,11 +1114,6 @@ export const Onboarding = ({
                         localStorage.getItem("local_npub")
                       );
                       setStep("5");
-                      setCurrentStep(3);
-                      if (onClose) {
-                        onClose();
-                      }
-                      navigate("/q/3");
                     }}
                     boxShadow="0.5px 0.5px 1px 0px black"
                     mb={18}
@@ -1216,11 +1185,6 @@ export const Onboarding = ({
                         localStorage.getItem("local_npub")
                       );
                       setStep("6");
-                      setCurrentStep(4);
-                      if (onClose) {
-                        onClose();
-                      }
-                      navigate("/q/4");
                     }}
                     boxShadow="0.5px 0.5px 1px 0px black"
                     mb={18}

--- a/src/components/OnboardingDrawer/OnboardingDrawer.jsx
+++ b/src/components/OnboardingDrawer/OnboardingDrawer.jsx
@@ -17,7 +17,6 @@ const TOTAL_STEPS = 6;
 export const OnboardingDrawer = ({
   userLanguage,
   setUserLanguage,
-  setCurrentStep,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [step, setStep] = useState(null);
@@ -52,6 +51,12 @@ export const OnboardingDrawer = ({
         onClick={onOpen}
         zIndex={1000}
         aria-label="Onboarding"
+        bgGradient="linear(to-r, teal.400, green.400)"
+        color="white"
+        boxShadow="0 0 12px rgba(0, 0, 0, 0.6)"
+        _hover={{ bgGradient: "linear(to-r, teal.500, green.500)" }}
+        boxSize={14}
+        border="2px solid white"
       />
       {remaining > 0 && (
         <Badge
@@ -73,10 +78,8 @@ export const OnboardingDrawer = ({
             <Onboarding
               userLanguage={userLanguage}
               setUserLanguage={setUserLanguage}
-              setCurrentStep={setCurrentStep}
               step={String(step)}
               setStep={setStep}
-              onClose={onClose}
             />
           </DrawerBody>
         </DrawerContent>

--- a/src/components/SettingsMenu/SelfPacedModal/SelfPacedOnboarding.jsx
+++ b/src/components/SettingsMenu/SelfPacedModal/SelfPacedOnboarding.jsx
@@ -25,7 +25,6 @@ import {
   updateUserData,
 } from "../../../utility/nosql";
 import { translation } from "../../../utility/translation";
-import { useNavigate } from "react-router-dom";
 import {
   database,
   // messaging
@@ -91,9 +90,7 @@ const SelfPacedOnboarding = ({
   setInterval,
   userId,
   userLanguage,
-  setCurrentStep,
 }) => {
-  const navigate = useNavigate();
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
 
   const [goalCount, setGoalCount] = useState(0);
@@ -168,9 +165,6 @@ const SelfPacedOnboarding = ({
       ),
       incrementUserOnboardingStep(userId),
     ]).catch(console.error);
-
-    setCurrentStep(2);
-    navigate("/q/2");
   };
 
   // Build the label for the streak timer slider.


### PR DESCRIPTION
## Summary
- add OnboardingDrawer with floating button and step counter
- embed existing onboarding flow in a drawer and hide button when done
- remove onboarding routes and related navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b53fce548326be8f0b4ce9c8c223