### PR TITLE
Use hearts for incorrect attempts and restyle onboarding award

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1353,6 +1353,8 @@ const Step = ({
   setCurrentStep,
   navigateWithTransition,
   setTransitionStats,
+  incorrectAttempts,
+  setIncorrectAttempts,
 }) => {
   let loot = buildSuperLoot();
 
@@ -5531,6 +5533,8 @@ function App({ isShutDown }) {
                       setCurrentStep={setCurrentStep}
                       navigateWithTransition={navigateWithTransition}
                       setTransitionStats={setTransitionStats}
+                      incorrectAttempts={incorrectAttempts}
+                      setIncorrectAttempts={setIncorrectAttempts}
                     />
                   </PrivateRoute>
                 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3377,7 +3377,7 @@ const Step = ({
             {/* {isPostingWithNostr ? (
               <CloudCanvas />
             ) : ( */}
-            <> 
+            <>
               {incorrectAttempts >= 5 && !isTimerExpired ? (
                 <>
                   <div style={{ maxWidth: 600 }}>
@@ -3430,17 +3430,24 @@ const Step = ({
                     transition="0.2s all ease-in-out"
                     borderBottomRightRadius={"0px"}
                   >
-                    {!isCorrect && incorrectAttempts > 0 && incorrectAttempts < 5 && (
-                      <HStack mb={2} spacing={1} justify="center" width="100%">
-                        {Array.from({ length: 5 }, (_, i) =>
-                          i < 5 - incorrectAttempts ? (
-                            <FaHeart key={i} color="red" />
-                          ) : (
-                            <FaRegHeart key={i} color="red" />
-                          )
-                        )}
-                      </HStack>
-                    )}
+                    {!isCorrect &&
+                      incorrectAttempts > 0 &&
+                      incorrectAttempts < 5 && (
+                        <HStack
+                          mb={2}
+                          spacing={1}
+                          justify="center"
+                          width="100%"
+                        >
+                          {Array.from({ length: 5 }, (_, i) =>
+                            i < 5 - incorrectAttempts ? (
+                              <FaHeart key={i} color="red" />
+                            ) : (
+                              <FaRegHeart key={i} color="red" />
+                            )
+                          )}
+                        </HStack>
+                      )}
                     <Text
                       textAlign={"left"}
                       color={isCorrect ? "orange.500" : "red.500"}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,7 +158,13 @@ import { KnowledgeLedgerModal } from "./components/SettingsMenu/KnowledgeLedgerM
 import { logEvent } from "firebase/analytics";
 import BitcoinOnboarding from "./components/BitcoinOnboarding/BitcoinOnboarding";
 import SyntaxHighlighter from "react-syntax-highlighter";
-import { FaBitcoin, FaMagic } from "react-icons/fa";
+import {
+  FaBitcoin,
+  FaMagic,
+  FaHeart,
+  FaRegHeart,
+  FaHeartBroken,
+} from "react-icons/fa";
 import MiniKitInitializer from "./MiniKitInitializer";
 
 import BitcoinModeModal from "./components/SettingsMenu/BitcoinModeModal/BitcoinModeModal";
@@ -2699,7 +2705,8 @@ const Step = ({
     functionCall();
     // }
   };
-  const emojiMap = ["😖", "😩", "😅", "😱", "🪦"];
+  const incorrectAttempts =
+    parseInt(localStorage.getItem("incorrectAttempts"), 10) || 0;
 
   const hasPasscode =
     localStorage.getItem("passcode") ===
@@ -3368,26 +3375,8 @@ const Step = ({
             {/* {isPostingWithNostr ? (
               <CloudCanvas />
             ) : ( */}
-            <>
-              {localStorage.getItem("incorrectAttempts") &&
-              parseInt(localStorage.getItem("incorrectAttempts")) > 0 ? (
-                <Text
-                  fontSize={"smaller"}
-                  background={"#ececec"}
-                  borderRadius={12}
-                  padding={4}
-                >
-                  {translation[userLanguage]["lockout.attempts"]} &nbsp;
-                  {localStorage.getItem("incorrectAttempts")} / 5{" "}
-                  {
-                    emojiMap[
-                      parseInt(localStorage.getItem("incorrectAttempts")) - 1
-                    ]
-                  }
-                </Text>
-              ) : null}
-              {parseInt(localStorage.getItem("incorrectAttempts")) >= 5 &&
-              !isTimerExpired ? (
+            <> 
+              {incorrectAttempts >= 5 && !isTimerExpired ? (
                 <>
                   <div style={{ maxWidth: 600 }}>
                     <Text
@@ -3396,6 +3385,13 @@ const Step = ({
                       borderRadius={12}
                       padding={4}
                     >
+                      <FaHeartBroken
+                        style={{
+                          display: "inline",
+                          marginRight: 4,
+                          color: "red",
+                        }}
+                      />
                       {translation[userLanguage]["lockout.message"]} <br />
                       <br />
                       <CountdownTimer
@@ -3446,6 +3442,17 @@ const Step = ({
                         />
                       ) : null}
                     </Text>
+                    {!isCorrect && incorrectAttempts > 0 && incorrectAttempts < 5 && (
+                      <HStack mt={2} spacing={1}>
+                        {Array.from({ length: 5 }, (_, i) =>
+                          i < 5 - incorrectAttempts ? (
+                            <FaHeart key={i} color="red" />
+                          ) : (
+                            <FaRegHeart key={i} color="red" />
+                          )
+                        )}
+                      </HStack>
+                    )}
                   </Box>
                 </RiseUpAnimation>
               )}{" "}
@@ -3470,7 +3477,7 @@ const Step = ({
                 currentStep > 0 &&
                 !isCorrect &&
                 !isSending &&
-                !(parseInt(localStorage.getItem("incorrectAttempts")) >= "5") &&
+                !(incorrectAttempts >= 5) &&
                 isTimerExpired ? (
                   <Button
                     fontSize="sm"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1654,6 +1654,7 @@ const Step = ({
         // Expiry has passed, reset attempts
         localStorage.removeItem("incorrectExpiry");
         localStorage.setItem("incorrectAttempts", 0);
+        setIncorrectAttempts(0);
       }
     }
 
@@ -1800,6 +1801,7 @@ const Step = ({
   useEffect(() => {
     if (isCorrect) {
       localStorage.setItem("incorrectAttempts", 0);
+      setIncorrectAttempts(0);
       let getRecipient = async () => {
         const userData = await getUserData(localStorage.getItem("local_npub"));
 
@@ -2097,6 +2099,7 @@ const Step = ({
   const resetAttempts = () => {
     localStorage.removeItem("incorrectAttempts");
     localStorage.removeItem("incorrectExpiry");
+    setIncorrectAttempts(0);
   };
 
   // Store correct answers in the database
@@ -2186,12 +2189,11 @@ const Step = ({
           if (jsonResponse.isCorrect) {
             setGrade(jsonResponse.grade);
           } else {
-            localStorage.setItem(
-              "incorrectAttempts",
-              parseInt(localStorage.getItem("incorrectAttempts")) + 1 || 1
-            );
+            const newAttempts = incorrectAttempts + 1;
+            setIncorrectAttempts(newAttempts);
+            localStorage.setItem("incorrectAttempts", newAttempts);
 
-            if (localStorage.getItem("incorrectAttempts") >= 5) {
+            if (newAttempts >= 5) {
               // Set expiration time 15 minutes ahead
               setIsTimerExpired(false);
               const expiryTime = new Date().getTime() + 15 * 60 * 1000;
@@ -2694,6 +2696,7 @@ const Step = ({
   const handleTimerExpire = () => {
     localStorage.removeItem("incorrectAttempts");
     localStorage.removeItem("incorrectExpiry");
+    setIncorrectAttempts(0);
     setIsTimerExpired(true); // Update state or perform any action
   };
 
@@ -2705,9 +2708,6 @@ const Step = ({
     functionCall();
     // }
   };
-  const incorrectAttempts =
-    parseInt(localStorage.getItem("incorrectAttempts"), 10) || 0;
-
   const hasPasscode =
     localStorage.getItem("passcode") ===
       import.meta.env.VITE_PATREON_PASSCODE || hasSubmittedPasscode;
@@ -3428,6 +3428,17 @@ const Step = ({
                     transition="0.2s all ease-in-out"
                     borderBottomRightRadius={"0px"}
                   >
+                    {!isCorrect && incorrectAttempts > 0 && incorrectAttempts < 5 && (
+                      <HStack mb={2} spacing={1} justify="center" width="100%">
+                        {Array.from({ length: 5 }, (_, i) =>
+                          i < 5 - incorrectAttempts ? (
+                            <FaHeart key={i} color="red" />
+                          ) : (
+                            <FaRegHeart key={i} color="red" />
+                          )
+                        )}
+                      </HStack>
+                    )}
                     <Text
                       textAlign={"left"}
                       color={isCorrect ? "orange.500" : "red.500"}
@@ -3442,17 +3453,6 @@ const Step = ({
                         />
                       ) : null}
                     </Text>
-                    {!isCorrect && incorrectAttempts > 0 && incorrectAttempts < 5 && (
-                      <HStack mt={2} spacing={1}>
-                        {Array.from({ length: 5 }, (_, i) =>
-                          i < 5 - incorrectAttempts ? (
-                            <FaHeart key={i} color="red" />
-                          ) : (
-                            <FaRegHeart key={i} color="red" />
-                          )
-                        )}
-                      </HStack>
-                    )}
                   </Box>
                 </RiseUpAnimation>
               )}{" "}
@@ -5095,6 +5095,9 @@ function App({ isShutDown }) {
   const [showClouds, setShowClouds] = useState(false);
   const [pendingPath, setPendingPath] = useState(null);
   const [pendingStep, setPendingStep] = useState(null);
+  const [incorrectAttempts, setIncorrectAttempts] = useState(
+    parseInt(localStorage.getItem("incorrectAttempts"), 10) || 0
+  );
   const defaultTransitionStats = {
     salary: 0,
     salaryProgress: 0,

--- a/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
+++ b/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
@@ -6,13 +6,12 @@ import {
   Modal,
   ModalOverlay,
   ModalContent,
-  ModalHeader,
   ModalFooter,
   ModalBody,
   HStack,
-  useToast,
   Image,
 } from "@chakra-ui/react";
+import { motion } from "framer-motion";
 import { CloudCanvas } from "../../elements/SunsetCanvas";
 
 import "prismjs/components/prism-clike";
@@ -35,7 +34,6 @@ const AwardModalOnboarding = ({
     localStorage.getItem("local_npub"),
     localStorage.getItem("local_nsec")
   );
-  const toast = useToast();
   useEffect(() => {
     async function getBadges() {
       let data = await getUserBadges();
@@ -53,34 +51,44 @@ const AwardModalOnboarding = ({
       size="4xl"
       scrollBehavior={"inside"}
       closeOnOverlayClick={false}
+      isCentered
     >
-      <ModalOverlay></ModalOverlay>
+      <ModalOverlay bg="rgba(255,255,255,0.8)" backdropFilter="blur(8px)" />
       <ModalContent
-        background={"#38628D"}
-        // color="white"
-        borderRadius="lg"
-        boxShadow="2xl"
+        as={motion.div}
+        initial={{ y: 80, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 80, opacity: 0 }}
+        transition={{ duration: 0.4 }}
+        bg="white"
+        borderRadius="xl"
+        boxShadow="xl"
         p={0}
         width="100%"
-
-        // style={{ fontFamily: "Roboto Serif, serif" }}
+        sx={{
+          position: "relative",
+          border: "8px solid transparent",
+          background:
+            "linear-gradient(white, white) padding-box, linear-gradient(135deg,#FFD700,#FF69B4,#DA70D6,#FFA500) border-box",
+          "&::before": {
+            content: '""',
+            position: "absolute",
+            top: "8px",
+            left: "8px",
+            right: "8px",
+            bottom: "8px",
+            border: "2px solid #FFD700",
+            borderRadius: "calc(var(--chakra-radii-xl) - 8px)",
+            pointerEvents: "none",
+          },
+        }}
       >
-        <ModalHeader
-          fontSize="3xl"
-          fontWeight="bold"
-          marginTop={0}
-          paddingTop={0}
-          padding={3}
-        >
-          <HStack>
-            <div style={{ color: "white" }}>
-              {/* {translation[userLanguage]["modal.learn.title"]} */}
+        <ModalBody p={6} color="gray.800" style={{ width: "100%" }}>
+          <HStack justifyContent="center" mb={4}>
+            <Text fontSize="xl" fontWeight="bold">
               {translation[userLanguage]["modal.title.decentralizedTranscript"]}
-            </div>
+            </Text>
           </HStack>
-        </ModalHeader>
-
-        <ModalBody p={8} style={{ width: "100%", color: "white" }}>
           {/* <ReactConfetti
             gravity={1.35}
             numberOfPieces={100}

--- a/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
+++ b/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
@@ -96,31 +96,39 @@ const AwardModalOnboarding = ({
           {translation[userLanguage]["modal.decentralizedTranscript.youEarned"]}
           <br />
           <Text mb={2}>{onboardingTranscript.name[userLanguage]}</Text>
-          <a
-            target="_blank"
-            href={`https://badges.page/a/${
-              onboardingTranscript["address"] || ""
-            }`}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                window.open(
-                  `https://badges.page/a/${
-                    onboardingTranscript["address"] || ""
-                  }`
-                );
-              }
+          <Box
+            style={{
+              width: "100%",
+              display: "flex",
+              justifyContent: "center",
             }}
           >
-            <Image
-              loading="eager"
-              src={onboardingTranscript["imgSrc"]}
-              width={150}
-              style={{
-                borderRadius: "33%",
-                boxShadow: "0.5px 0.5px 1px 0px rgba(0,0,0,0.75)",
+            <a
+              target="_blank"
+              href={`https://badges.page/a/${
+                onboardingTranscript["address"] || ""
+              }`}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  window.open(
+                    `https://badges.page/a/${
+                      onboardingTranscript["address"] || ""
+                    }`
+                  );
+                }
               }}
-            />
-          </a>
+            >
+              <Image
+                loading="eager"
+                src={onboardingTranscript["imgSrc"]}
+                width={150}
+                style={{
+                  borderRadius: "33%",
+                  boxShadow: "0.5px 0.5px 1px 0px rgba(0,0,0,0.75)",
+                }}
+              />
+            </a>
+          </Box>
           <br />
           <br />
           {/* <Button

--- a/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
+++ b/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
@@ -48,8 +48,7 @@ const AwardModalOnboarding = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      size="4xl"
-      scrollBehavior={"inside"}
+      size="lg"
       closeOnOverlayClick={false}
       isCentered
     >
@@ -64,7 +63,6 @@ const AwardModalOnboarding = ({
         borderRadius="xl"
         boxShadow="xl"
         p={0}
-        width="100%"
         sx={{
           position: "relative",
           border: "8px solid transparent",
@@ -83,7 +81,7 @@ const AwardModalOnboarding = ({
           },
         }}
       >
-        <ModalBody p={6} color="gray.800" style={{ width: "100%" }}>
+        <ModalBody p={6} color="gray.800" textAlign="center">
           <HStack justifyContent="center" mb={4}>
             <Text fontSize="xl" fontWeight="bold">
               {translation[userLanguage]["modal.title.decentralizedTranscript"]}
@@ -97,9 +95,7 @@ const AwardModalOnboarding = ({
           /> */}
           {translation[userLanguage]["modal.decentralizedTranscript.youEarned"]}
           <br />
-          <Text fontSize={"large"} fontWeight={"bold"} mb={2}>
-            {onboardingTranscript.name[userLanguage]}
-          </Text>
+          <Text mb={2}>{onboardingTranscript.name[userLanguage]}</Text>
           <a
             target="_blank"
             href={`https://badges.page/a/${

--- a/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
+++ b/src/components/AwardModalOnboarding/AwardModalOnboarding.jsx
@@ -28,12 +28,12 @@ const AwardModalOnboarding = ({
   userLanguage,
   handleActuallyReallySeriouslyLaunchApp,
 }) => {
-  const [badges, setBadges] = useState([]);
   const [areBadgesLoading, setAreBadgesLoading] = useState(true);
   const { getUserBadges } = useSharedNostr(
     localStorage.getItem("local_npub"),
     localStorage.getItem("local_nsec")
   );
+  const [badges, setBadges] = useState([]);
   useEffect(() => {
     async function getBadges() {
       let data = await getUserBadges();

--- a/src/components/SettingsMenu/TranscriptModal/TranscriptModal.jsx
+++ b/src/components/SettingsMenu/TranscriptModal/TranscriptModal.jsx
@@ -60,7 +60,7 @@ const TranscriptModal = ({ isOpen, onClose, userLanguage }) => {
           border: "8px solid transparent",
           background:
             "linear-gradient(white, white) padding-box, linear-gradient(135deg,#FFD700,#FF69B4,#DA70D6,#FFA500) border-box",
-          '&::before': {
+          "&::before": {
             content: '""',
             position: "absolute",
             top: "8px",
@@ -87,12 +87,16 @@ const TranscriptModal = ({ isOpen, onClose, userLanguage }) => {
                 borderRadius="33%"
                 boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
               />
-            ) : (
-              <ReactConfetti numberOfPieces={80} recycle={false} />
-            )}
+            ) : null
+            // <ReactConfetti numberOfPieces={80} recycle={false} />
+            }
           </Box>
           <Text mb={4}>
-            {translation[userLanguage]["modal.decentralizedTranscript.awareness"]}
+            {
+              translation[userLanguage][
+                "modal.decentralizedTranscript.awareness"
+              ]
+            }
           </Text>
           <Box display="flex" flexWrap="wrap" justifyContent="center">
             {badges.map((badge) => (

--- a/src/components/SettingsMenu/TranscriptModal/TranscriptModal.jsx
+++ b/src/components/SettingsMenu/TranscriptModal/TranscriptModal.jsx
@@ -74,10 +74,7 @@ const TranscriptModal = ({ isOpen, onClose, userLanguage }) => {
         }}
       >
         <ModalBody p={6} color="gray.800">
-          <HStack justifyContent="space-between" mb={4}>
-            <Text fontSize="xl" fontWeight="bold">
-              {translation[userLanguage]["modal.title.decentralizedTranscript"]}
-            </Text>
+          <HStack justifyContent="center" mb={4}>
             <Text fontSize="xl" fontWeight="bold">
               {translation[userLanguage]["modal.title.decentralizedTranscript"]}
             </Text>

--- a/src/utility/content.jsx
+++ b/src/utility/content.jsx
@@ -13186,14 +13186,15 @@ export const loot = [
   },
   {
     monetaryValue: 500,
-    en: "Recognising primitive data types enables safe edits to JSON or environment files.",
-    es: "Reconocer los tipos de datos primitivos permite editar de forma segura archivos JSON o de entorno.",
-  },
-  {
-    monetaryValue: 750,
     en: "Creating an array makes simple data‑entry automations (lists, CSV tweaks) possible.",
     es: "Crear un arreglo hace posibles automatizaciones simples de ingreso de datos (listas, ajustes de CSV).",
   },
+  {
+    monetaryValue: 750,
+    en: "Recognising primitive data types enables safe edits to files.",
+    es: "Reconocer los tipos de datos primitivos permite editar de forma segura archivos JSON o de entorno.",
+  },
+
   {
     monetaryValue: 1000,
     en: "Writing a working code snippet shows executable output—sellable micro‑tasks begin here.",


### PR DESCRIPTION
## Summary
- Replace numeric incorrect-attempt counter with five-heart indicator that depletes in the wrong-answer bubble
- Show broken heart and lockout message after all hearts are gone
- Restyle onboarding award modal to match gradient-bordered award/transcript modals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm install` *(fails: 403 Forbidden fetching ajv)*

------
https://chatgpt.com/codex/tasks/task_e_6895c30118508326a857ebb80ef804c5