### PR TITLE
Retrieve user badges in award modals

### DIFF
--- a/src/components/AwardModal/AwardModal.jsx
+++ b/src/components/AwardModal/AwardModal.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -10,6 +10,7 @@ import {
   ModalFooter,
   HStack,
   Image,
+  Link,
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import ReactConfetti from "react-confetti";
@@ -19,11 +20,38 @@ import {
   videoTranscript,
   computerScienceTranscript,
 } from "../../utility/transcript";
+import { useSharedNostr } from "../../hooks/useNOSTR";
+import { nip19 } from "nostr-tools";
 
 const AwardModal = ({ isOpen, onClose, step, userLanguage }) => {
   const transcriptset =
     userLanguage === "compsci-en" ? computerScienceTranscript : transcript;
   const badge = transcriptset[step.group] || {};
+  const [badges, setBadges] = useState([]);
+  const { getUserBadges } = useSharedNostr(
+    localStorage.getItem("local_npub"),
+    localStorage.getItem("local_nsec")
+  );
+
+  useEffect(() => {
+    async function fetchBadges() {
+      if (isOpen) {
+        const data = await getUserBadges();
+        setBadges(data || []);
+      }
+    }
+    fetchBadges();
+  }, [isOpen]);
+
+  const getNaddr = (address) => {
+    if (address.startsWith("naddr")) return address;
+    const [kind, pubkey, identifier] = address.split(":");
+    return nip19.naddrEncode({
+      kind: parseInt(kind),
+      pubkey,
+      identifier,
+    });
+  };
 
   return (
     <Modal
@@ -91,6 +119,29 @@ const AwardModal = ({ isOpen, onClose, step, userLanguage }) => {
               ]
             }
           </Text>
+          <Box display="flex" flexWrap="wrap" justifyContent="center" mt={4}>
+            {badges.map((bdge) => (
+              <Box key={bdge.badgeAddress} m={2} textAlign="center">
+                <Link
+                  href={`https://badges.page/a/${getNaddr(
+                    bdge.badgeAddress
+                  )}`}
+                  target="_blank"
+                >
+                  <Image
+                    src={bdge.image}
+                    width={100}
+                    borderRadius="33%"
+                    boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
+                    mb={2}
+                  />
+                </Link>
+                <Text fontSize="sm">
+                  {translation[userLanguage][bdge.name] || bdge.name}
+                </Text>
+              </Box>
+            ))}
+          </Box>
         </ModalBody>
         <ModalFooter justifyContent="center">
           <Button

--- a/src/components/SettingsMenu/TranscriptModal/TranscriptModal.jsx
+++ b/src/components/SettingsMenu/TranscriptModal/TranscriptModal.jsx
@@ -10,6 +10,7 @@ import {
   ModalFooter,
   HStack,
   Image,
+  Link,
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import ReactConfetti from "react-confetti";
@@ -20,6 +21,7 @@ import {
   computerScienceTranscript,
 } from "../../../utility/transcript";
 import { useSharedNostr } from "../../../hooks/useNOSTR";
+import { nip19 } from "nostr-tools";
 
 const TranscriptModal = ({ isOpen, onClose, userLanguage }) => {
   const transcriptset =
@@ -39,6 +41,16 @@ const TranscriptModal = ({ isOpen, onClose, userLanguage }) => {
     }
     fetchBadges();
   }, [isOpen]);
+
+  const getNaddr = (address) => {
+    if (address.startsWith("naddr")) return address;
+    const [kind, pubkey, identifier] = address.split(":");
+    return nip19.naddrEncode({
+      kind: parseInt(kind),
+      pubkey,
+      identifier,
+    });
+  };
 
   const cardImage = badges[0]?.image;
 
@@ -100,14 +112,19 @@ const TranscriptModal = ({ isOpen, onClose, userLanguage }) => {
           </Text>
           <Box display="flex" flexWrap="wrap" justifyContent="center">
             {badges.map((badge) => (
-              <Box key={badge.id} m={2} textAlign="center">
-                <Image
-                  src={badge.image}
-                  width={100}
-                  borderRadius="33%"
-                  boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
-                  mb={2}
-                />
+              <Box key={badge.badgeAddress} m={2} textAlign="center">
+                <Link
+                  href={`https://badges.page/a/${getNaddr(badge.badgeAddress)}`}
+                  target="_blank"
+                >
+                  <Image
+                    src={badge.image}
+                    width={100}
+                    borderRadius="33%"
+                    boxShadow="0.5px 0.5px 1px rgba(0,0,0,0.75)"
+                    mb={2}
+                  />
+                </Link>
                 <Text fontSize="sm">
                   {translation[userLanguage][badge.name] || badge.name}
                 </Text>


### PR DESCRIPTION
## Summary
- Fetch user's Nostr badges in award modal and show them as linked images
- Link badges to their badge pages in transcript modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_689663dc70208326a963e9f5dacb647f