### PR TITLE
feat: track sat balance and update deposit

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1856,7 +1856,7 @@ const Step = ({
       null;
     if (totalBalance < 0) return 0;
 
-    return (totalBalance / 10) * 100;
+    return Math.min((totalBalance / 100) * 100, 100);
   };
 
   // Calculate progress within the current chapter
@@ -2310,8 +2310,7 @@ const Step = ({
 
     const salaryVal = loot[currentStep]["monetaryValue"] || 0;
     const salaryProgress = (salaryVal / 120000) * 100;
-    const totalSteps = steps[userLanguage].length;
-    const stepProgress = ((currentStep + 1) / totalSteps) * 100;
+    const balanceProgress = calculateBalance();
     const salaryText = loot[currentStep][userLanguage];
     const updatedDailyProgress = Math.min(dailyProgress + 1, dailyGoals || 5);
     const dailyGoalPercent = Math.min(
@@ -2321,7 +2320,7 @@ const Step = ({
     setTransitionStats({
       salary: salaryVal,
       salaryProgress,
-      stepProgress,
+      balanceProgress,
       dailyGoalProgress: dailyGoalPercent,
       dailyProgress: updatedDailyProgress,
       dailyGoals: dailyGoals || 5,
@@ -5126,7 +5125,7 @@ function App({ isShutDown }) {
   const defaultTransitionStats = {
     salary: 0,
     salaryProgress: 0,
-    stepProgress: 0,
+    balanceProgress: 0,
     dailyGoalProgress: 0,
     dailyProgress: 0,
     dailyGoals: 0,
@@ -5430,7 +5429,7 @@ function App({ isShutDown }) {
         isActive={showClouds}
         salary={transitionStats.salary}
         salaryProgress={transitionStats.salaryProgress}
-        stepProgress={transitionStats.stepProgress}
+        balanceProgress={transitionStats.balanceProgress}
         dailyGoalProgress={transitionStats.dailyGoalProgress}
         dailyProgress={transitionStats.dailyProgress}
         dailyGoals={transitionStats.dailyGoals}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2310,6 +2310,8 @@ const Step = ({
 
     const salaryVal = loot[currentStep]["monetaryValue"] || 0;
     const salaryProgress = (salaryVal / 120000) * 100;
+    const totalSteps = steps[userLanguage].length;
+    const stepProgress = ((currentStep + 1) / totalSteps) * 100;
     const balanceProgress = calculateBalance();
     const salaryText = loot[currentStep][userLanguage];
     const updatedDailyProgress = Math.min(dailyProgress + 1, dailyGoals || 5);
@@ -2320,6 +2322,7 @@ const Step = ({
     setTransitionStats({
       salary: salaryVal,
       salaryProgress,
+      stepProgress,
       balanceProgress,
       dailyGoalProgress: dailyGoalPercent,
       dailyProgress: updatedDailyProgress,
@@ -5125,6 +5128,7 @@ function App({ isShutDown }) {
   const defaultTransitionStats = {
     salary: 0,
     salaryProgress: 0,
+    stepProgress: 0,
     balanceProgress: 0,
     dailyGoalProgress: 0,
     dailyProgress: 0,
@@ -5429,6 +5433,7 @@ function App({ isShutDown }) {
         isActive={showClouds}
         salary={transitionStats.salary}
         salaryProgress={transitionStats.salaryProgress}
+        stepProgress={transitionStats.stepProgress}
         balanceProgress={transitionStats.balanceProgress}
         dailyGoalProgress={transitionStats.dailyGoalProgress}
         dailyProgress={transitionStats.dailyProgress}

--- a/src/components/BitcoinOnboarding/BitcoinOnboarding.jsx
+++ b/src/components/BitcoinOnboarding/BitcoinOnboarding.jsx
@@ -143,8 +143,8 @@ const BitcoinOnboarding = ({ userLanguage }) => {
   const handleInitiateDeposit = async () => {
     setDepositing(true);
     try {
-      // Initiate a deposit for 10 sats (example)
-      const pr = await initiateDeposit(10);
+      // Initiate a deposit for 100 sats (example)
+      const pr = await initiateDeposit(100);
       // pr is a LN invoice (bolt11)
       // if (pr) {
       //   setLnInvoice(pr);
@@ -165,8 +165,8 @@ const BitcoinOnboarding = ({ userLanguage }) => {
   const generateNewQR = async () => {
     setIsGeneratingNewQR(true);
     try {
-      // Initiate a deposit for 10 sats (example)
-      const pr = await initiateDeposit(10);
+      // Initiate a deposit for 100 sats (example)
+      const pr = await initiateDeposit(100);
       // pr is a LN invoice (bolt11)
       // if (pr) {
       //   setLnInvoice(pr);

--- a/src/components/SettingsMenu/BitcoinModeModal/BitcoinModeModal.jsx
+++ b/src/components/SettingsMenu/BitcoinModeModal/BitcoinModeModal.jsx
@@ -180,8 +180,8 @@ const BitcoinModeModal = ({
   // const handleInitiateDeposit = async () => {
   //   setDepositing(true);
   //   try {
-  //     // Initiate a deposit for 10 sats (example)
-  //     const pr = await initiateDeposit(10);
+  //     // Initiate a deposit for 100 sats (example)
+  //     const pr = await initiateDeposit(100);
   //     // pr is a LN invoice (bolt11)
   //     // if (pr) {
   //     //   setLnInvoice(pr);

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -174,6 +174,7 @@ const CloudTransition = ({
   isActive,
   salary,
   salaryProgress,
+  stepProgress,
   balanceProgress,
   dailyGoalProgress,
   dailyProgress,
@@ -484,6 +485,21 @@ const CloudTransition = ({
                       start="#43e97b"
                       end="#38f9d7"
                       delay={0.2}
+                      bg="rgba(255,255,255,0.65)"
+                      border="#ededed"
+                    />
+                  </Box>
+
+                  {/* Step progress bar */}
+                  <Box w="100%" mx="auto" mb={6}>
+                    <Text fontSize="sm" mb={1} color="purple.500">
+                      Progress
+                    </Text>
+                    <WaveBar
+                      value={stepProgress}
+                      start="#6a11cb"
+                      end="#72a2f2"
+                      delay={0.1}
                       bg="rgba(255,255,255,0.65)"
                       border="#ededed"
                     />

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -174,7 +174,7 @@ const CloudTransition = ({
   isActive,
   salary,
   salaryProgress,
-  stepProgress,
+  balanceProgress,
   dailyGoalProgress,
   dailyProgress,
   dailyGoals,
@@ -489,13 +489,13 @@ const CloudTransition = ({
                     />
                   </Box>
 
-                  {/* Step progress bar */}
+                  {/* Balance bar */}
                   <Box w="100%" mx="auto" mb={6}>
                     <Text fontSize="sm" mb={1} color="purple.500">
-                      Progress
+                      Balance {balanceProgress}/100 sats
                     </Text>
                     <WaveBar
-                      value={stepProgress}
+                      value={balanceProgress}
                       start="#6a11cb"
                       end="#72a2f2"
                       delay={0.1}

--- a/src/elements/CloudTransition.jsx
+++ b/src/elements/CloudTransition.jsx
@@ -489,6 +489,20 @@ const CloudTransition = ({
                       border="#ededed"
                     />
                   </Box>
+                  {/* Balance bar */}
+                  <Box w="100%" mx="auto" mb={6}>
+                    <Text fontSize="sm" mb={1} color="purple.500">
+                      {balanceProgress} Bitcoin sats
+                    </Text>
+                    <WaveBar
+                      value={balanceProgress}
+                      start="#fce09d"
+                      end="#fef37b"
+                      delay={0}
+                      bg="rgba(255,255,255,0.65)"
+                      border="#ededed"
+                    />
+                  </Box>
 
                   {/* Step progress bar */}
                   <Box w="100%" mx="auto" mb={6}>
@@ -497,23 +511,8 @@ const CloudTransition = ({
                     </Text>
                     <WaveBar
                       value={stepProgress}
-                      start="#6a11cb"
-                      end="#72a2f2"
-                      delay={0.1}
-                      bg="rgba(255,255,255,0.65)"
-                      border="#ededed"
-                    />
-                  </Box>
-
-                  {/* Balance bar */}
-                  <Box w="100%" mx="auto" mb={6}>
-                    <Text fontSize="sm" mb={1} color="purple.500">
-                      Balance {balanceProgress}/100 sats
-                    </Text>
-                    <WaveBar
-                      value={balanceProgress}
-                      start="#6a11cb"
-                      end="#72a2f2"
+                      start="#0345fc"
+                      end="#03f4fc"
                       delay={0.1}
                       bg="rgba(255,255,255,0.65)"
                       border="#ededed"
@@ -527,7 +526,7 @@ const CloudTransition = ({
                     </Text>
                     <WaveBar
                       value={dailyGoalProgress}
-                      start="#fce09d"
+                      start="#03f4fc"
                       end="#fef37b"
                       delay={0}
                       bg="rgba(255,255,255,0.65)"

--- a/src/elements/IdentityCard.jsx
+++ b/src/elements/IdentityCard.jsx
@@ -218,9 +218,9 @@ export const IdentityCard = ({
       }}
     >
       This code is an address that you can use to send Bitcoin from your Cash
-      App. This is an experimental feature that will have you deposit $0.02
-      worth of Bitcoin. The app is designed to charge you 1 Bitcoin cent called
-      sats. Depositing 2 cents USD of sats grants you about 30 charges of the
+      App. This is an experimental feature that will have you deposit $0.10
+      worth of Bitcoin. The app is designed to charge you 10 Bitcoin cents called
+      sats. Depositing 10 cents USD of sats grants you about 100 charges of the
       app. QR codes soon!
       <a
         target="_blank"

--- a/src/experiments/SmartWallet.jsx
+++ b/src/experiments/SmartWallet.jsx
@@ -26,7 +26,7 @@
 //     }
 //   };
 
-//   // Send a transaction (1 cent)
+//   // Send a transaction (10 cents)
 //   const sendTransaction = async () => {
 //     if (!address) {
 //       alert("Please connect wallet first");
@@ -34,8 +34,8 @@
 //     }
 
 //     try {
-//       // Convert 1 cent to wei. Note: This is a very rough estimate, actual value depends on ETH price.
-//       const amountInWei = ethers.utils.parseUnits("0.01", 18); // Assuming 1 cent is roughly 0.01 ETH at some point
+//       // Convert 10 cents to wei. Note: This is a very rough estimate, actual value depends on ETH price.
+//       const amountInWei = ethers.utils.parseUnits("0.10", 18); // Assuming 10 cents is roughly 0.10 ETH at some point
 
 //       const provider = wallet.makeWeb3Provider();
 //       const signer = provider.getSigner();


### PR DESCRIPTION
## Summary
- Raise bitcoin deposit example to 100 sats and update related copy
- Introduce balance progress bar in cloud transition to track remaining sats
- Adjust onboarding and identity text to describe new 10-cent, 100-sat deposit

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*


------
https://chatgpt.com/codex/tasks/task_e_6899978901888326b6423b2e2cb78fef