### PR TITLE
Fix proof removal to prevent double counting

### DIFF
--- a/src/hooks/useCashuWallet.jsx
+++ b/src/hooks/useCashuWallet.jsx
@@ -44,7 +44,9 @@ export const useProofStorage = () => {
   const removeProofs = (proofsToRemove) => {
     if (!proofsToRemove) return;
     setProofs((prevProofs) =>
-      prevProofs.filter((proof) => !proofsToRemove.includes(proof))
+      prevProofs.filter(
+        (proof) => !proofsToRemove.some((p) => p.secret === proof.secret)
+      )
     );
   };
 

--- a/src/useCashuStore.jsx
+++ b/src/useCashuStore.jsx
@@ -69,7 +69,7 @@ const useCashuStore = create((set, get) => ({
     if (!proofsToRemove) return;
 
     const updatedProofs = proofs.filter(
-      (proof) => !proofsToRemove.includes(proof)
+      (proof) => !proofsToRemove.some((p) => p.secret === proof.secret)
     );
     const newBalance = updatedProofs.reduce(
       (total, proof) => total + proof.amount,


### PR DESCRIPTION
## Summary
- remove spent proofs based on secret so they aren't counted twice

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899a8de39808326b2a3288d78036f22