### PR TITLE
feat: add demo question to landing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,6 +127,7 @@ import { DataTags } from "./elements/DataTag";
 import { transcript } from "./utility/transcript";
 import AwardModal from "./components/AwardModal/AwardModal";
 import CodeCompletionQuestion from "./components/CodeCompletionQuestion/CodeCompletionQuestion";
+import DemoQuestion from "./components/Landing/DemoQuestion";
 
 import isEmpty from "lodash/isEmpty";
 import {
@@ -4347,9 +4348,10 @@ const Home = ({
                   onChange={handleToggle}
                   onKeyDown={(e) => e.key === "Enter" && handleToggle()}
                 />
-              </FormControl>
-            </VStack>
+            </FormControl>
           </VStack>
+          <DemoQuestion userLanguage={userLanguage} />
+        </VStack>
 
           {/* First slide: Why Learn */}
           <Box

--- a/src/components/Landing/DemoQuestion.jsx
+++ b/src/components/Landing/DemoQuestion.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { VStack, Button, Text } from "@chakra-ui/react";
+import CodeCompletionQuestion from "../CodeCompletionQuestion/CodeCompletionQuestion";
+import { steps } from "../../utility/content";
+import { translation } from "../../utility/translation";
+
+// Global user used for demo purposes
+const GLOBAL_USER = { id: "demo-user" };
+
+const DemoQuestion = ({ userLanguage }) => {
+  const demoStep = steps["compsci-en"][4];
+  const [selectedOption, setSelectedOption] = useState(null);
+  const [feedbackKey, setFeedbackKey] = useState("");
+
+  const checkAnswer = () => {
+    const isCorrect = selectedOption === demoStep.question.answer;
+    GLOBAL_USER.lastAnswerCorrect = isCorrect;
+    setFeedbackKey(isCorrect ? "demo.correct" : "demo.incorrect");
+  };
+
+  return (
+    <VStack spacing={4} mt={8} width="100%" maxWidth="600px">
+      <Text fontSize="md" fontWeight="bold">
+        {demoStep.title}
+      </Text>
+      <CodeCompletionQuestion
+        step={demoStep}
+        question={demoStep.question}
+        selectedOption={selectedOption}
+        setSelectedOption={setSelectedOption}
+        onLearnClick={() => {}}
+        userLanguage={userLanguage}
+        handleModalCheck={(fn) => fn()}
+      />
+      <Button
+        colorScheme="green"
+        onMouseDown={checkAnswer}
+        isDisabled={!selectedOption}
+      >
+        {translation[userLanguage]["app.button.answer"]}
+      </Button>
+      {feedbackKey && (
+        <Text fontSize="sm">
+          {translation[userLanguage][feedbackKey]}
+        </Text>
+      )}
+    </VStack>
+  );
+};
+
+export default DemoQuestion;

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -76,6 +76,8 @@ export let translation = {
     skip: "Skip",
 
     runCode: "Run code",
+    "demo.correct": "Correct!",
+    "demo.incorrect": "Try again.",
     "modal.selfPace.weekPlan": "Set up 1 week plan",
     "modal.selfPace.monthPlan": "Set up 1 month plan",
     "modal.dailyGoal.estimate":
@@ -1701,6 +1703,8 @@ reverse(head) {
       "Esta aplicación crecerá y se adaptará contigo a medida que aprendes y avanzas. Por ahora, comenzaremos con una aplicación sencilla para mostrarte algunas cosas que vas a aprender. Más adelante podrás cambiar tu idea.",
     skip: "Saltar",
     runCode: "Ejecutar programa",
+    "demo.correct": "¡Correcto!",
+    "demo.incorrect": "Inténtalo de nuevo.",
     "modal.selfPace.weekPlan": "Configurar plan de 1 semana",
     "modal.selfPace.monthPlan": "Configurar plan de 1 mes",
     "app.terminal.placeholder": "Escribe tu respuesta aquí",


### PR DESCRIPTION
## Summary
- add demo question component with a global demo user so visitors can try a question
- wire demo question into landing view
- translate demo feedback strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_689ac02d1e648326a947e85314161baf