### PR TITLE
Show real-time question count on landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,6 +71,7 @@ import {
   incrementUserStep,
   setOnboardingToDone,
   updateUserData,
+  incrementQuestionsAnswered,
 } from "./utility/nosql";
 import {
   getObjectsByGroup,
@@ -2275,6 +2276,7 @@ const Step = ({
       logEvent(analytics, "handleNextClick", {
         action: "completed_question",
       });
+      await incrementQuestionsAnswered();
     } else {
       // window.alert("you cant do that buddy");
     }

--- a/src/components/Landing/Landing.jsx
+++ b/src/components/Landing/Landing.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Box,
   VStack,
@@ -14,7 +14,12 @@ import {
 import { useNavigate } from "react-router-dom";
 import { CloudCanvas } from "../../elements/SunsetCanvas";
 import { translation } from "../../utility/translation";
-import { createUser, updateUserData } from "../../utility/nosql";
+import {
+  createUser,
+  updateUserData,
+  subscribeToQuestionsAnswered,
+  BASE_QUESTION_COUNT,
+} from "../../utility/nosql";
 
 export const Landing = ({
   userLanguage,
@@ -36,6 +41,14 @@ export const Landing = ({
   const [loadingMessage, setLoadingMessage] = useState(
     "createAccount.isCreating"
   );
+  const [questionsAnswered, setQuestionsAnswered] = useState(
+    BASE_QUESTION_COUNT
+  );
+
+  useEffect(() => {
+    const unsubscribe = subscribeToQuestionsAnswered(setQuestionsAnswered);
+    return () => unsubscribe();
+  }, []);
 
   const toast = useToast();
   const navigate = useNavigate();
@@ -54,6 +67,10 @@ export const Landing = ({
         <Text fontSize="xl">{translation[userLanguage]["landing.title"]}</Text>
         <Text fontSize="sm" mt={-2}>
           {translation[userLanguage]["landing.introduction"]}
+        </Text>
+        <Text fontSize="md">
+          {translation[userLanguage]["landing.questionsAnswered"]}{" "}
+          {questionsAnswered}
         </Text>
       </VStack>
 

--- a/src/utility/nosql.jsx
+++ b/src/utility/nosql.jsx
@@ -9,6 +9,8 @@ import {
   query,
   where,
   deleteDoc,
+  onSnapshot,
+  increment,
 } from "firebase/firestore";
 import { database } from "../database/firebaseResources";
 
@@ -222,4 +224,18 @@ export const fetchUsersWithToken = async () => {
   querySnapshot.forEach((doc) => {
     console.log(`User ID: ${doc.id}`, doc.data());
   });
+};
+
+// Global question count utilities
+const questionDoc = doc(database, "analytics", "questionsAnswered");
+export const BASE_QUESTION_COUNT = 4200;
+
+export const subscribeToQuestionsAnswered = (callback) =>
+  onSnapshot(questionDoc, (snap) => {
+    const extra = snap.data()?.count || 0;
+    callback(BASE_QUESTION_COUNT + extra);
+  });
+
+export const incrementQuestionsAnswered = async () => {
+  await setDoc(questionDoc, { count: increment(1) }, { merge: true });
 };

--- a/src/utility/translation.jsx
+++ b/src/utility/translation.jsx
@@ -914,6 +914,7 @@ reverse(head) {
         {/* Use intelligent assistance to learn how to code quickly and efficiently. */}
       </div>
     ),
+    "landing.questionsAnswered": "Questions answered:",
     "landing.button.telemetry": "Create Account",
     "landing.button.signIn": "Sign In",
     "createAccount.instructions": "All we need to start is a user name.",
@@ -2714,6 +2715,7 @@ Las Estructuras de Datos y Algoritmos es una materia que a menudo intimida a los
         ideas.
       </div>
     ),
+    "landing.questionsAnswered": "Preguntas contestadas:",
     "landing.button.telemetry": "Crear Cuenta",
     "landing.button.signIn": "Iniciar Sesión",
     "createAccount.instructions":


### PR DESCRIPTION
## Summary
- track global questions answered starting from base 4200
- increment global counter on each question completion
- display live questions answered on landing page before login

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package 'eslint-plugin-react')

------
https://chatgpt.com/codex/tasks/task_e_689c5c9663b483268ea5fb24c071ec37