### PR TITLE
Normalize Cashu wallet balance handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -95,6 +95,7 @@ import {
 import { analytics, database } from "./database/firebaseResources";
 
 import { pickProgrammingLanguage, translation } from "./utility/translation";
+import { getCashuBalanceTotal } from "./utility/cashu";
 
 import { Dashboard } from "./components/Dashboard/Dashboard";
 import { isUnsupportedBrowser } from "./utility/browser";
@@ -1854,12 +1855,10 @@ const Step = ({
   }, [isCorrect]);
 
   const calculateBalance = () => {
-    const totalBalance =
-      (walletBalance || [])?.reduce((sum, b) => sum + (b.amount || 0), 0) ||
-      null;
-    if (totalBalance < 0) return 0;
+    const totalBalance = getCashuBalanceTotal(walletBalance);
+    if (totalBalance <= 0) return 0;
 
-    return Math.min((totalBalance / 100) * 100, 100);
+    return Math.min(totalBalance, 100);
   };
 
   // Calculate progress within the current chapter

--- a/src/components/BitcoinOnboarding/BitcoinOnboarding.jsx
+++ b/src/components/BitcoinOnboarding/BitcoinOnboarding.jsx
@@ -21,6 +21,7 @@ import { SiCashapp } from "react-icons/si";
 import { BsQrCode } from "react-icons/bs";
 
 import { translation } from "../../utility/translation";
+import { getCashuBalanceTotal } from "../../utility/cashu";
 
 import { useNostrWalletStore } from "../../hooks/useNostrWalletStore";
 import { database } from "../../database/firebaseResources";
@@ -40,7 +41,7 @@ const BitcoinOnboarding = ({ userLanguage }) => {
    * Hook from useSharedNostr:
    * - createNewWallet(): creates a new Cashu wallet event and sets up the wallet
    * - initiateDeposit(amount): returns a LN invoice to deposit sats
-   * - walletBalance: array of proofs; sum their values to get total balance
+   * - walletBalance: numeric balance (sats) available in the wallet
    * - cashuWallet: if null, no wallet yet
    */
 
@@ -86,8 +87,8 @@ const BitcoinOnboarding = ({ userLanguage }) => {
   // Helper: sum up wallet balance
 
   console.log("total balance", walletBalance);
-  const totalBalance =
-    (walletBalance || [])?.reduce((sum, b) => sum + (b.amount || 0), 0) || null;
+  const computedBalance = getCashuBalanceTotal(walletBalance);
+  const totalBalance = computedBalance > 0 ? computedBalance : null;
 
   useEffect(() => {
     // If we have a deposit in progress and the user pays it, after proofs update

--- a/src/components/SettingsMenu/BitcoinModeModal/BitcoinModeModal.jsx
+++ b/src/components/SettingsMenu/BitcoinModeModal/BitcoinModeModal.jsx
@@ -42,7 +42,7 @@ const BitcoinModeModal = ({
   //  * Hook from useSharedNostr:
   //  * - createNewWallet(): creates a new Cashu wallet event and sets up the wallet
   //  * - initiateDeposit(amount): returns a LN invoice to deposit sats
-  //  * - walletBalance: array of proofs; sum their values to get total balance
+  //  * - walletBalance: numeric balance (sats) available in the wallet
   //  * - cashuWallet: if null, no wallet yet
   //  */
 

--- a/src/hooks/useNostrWalletStore.jsx
+++ b/src/hooks/useNostrWalletStore.jsx
@@ -10,6 +10,7 @@ import { Buffer } from "buffer";
 import { bech32 } from "bech32";
 
 import NDKWalletService, { NDKCashuWallet } from "@nostr-dev-kit/ndk-wallet";
+import { normalizeCashuBalance } from "../utility/cashu";
 
 const defaultMint = "https://mint.minibits.cash/Bitcoin";
 const defaultRelays = ["wss://relay.damus.io", "wss://relay.primal.net"];
@@ -162,7 +163,7 @@ export const useNostrWalletStore = create((set, get) => ({
     // listen for updates to the balance, when a user answers a question, the balance should update
     wallet.on("balance_updated", async (balance) => {
       console.log("arg balance", balance);
-      const bal = (await wallet.balance()) || [];
+      const bal = normalizeCashuBalance(balance || (await wallet.balance()));
       console.log("balanace...", bal);
       set({ walletBalance: bal });
     });
@@ -170,7 +171,7 @@ export const useNostrWalletStore = create((set, get) => ({
     // potentially writing a bug here
     // essentially checking the balance redundantly, resulting in outdated balance
     //woudn't be surprised if this runs first actually, we'll see
-    const initialBal = (await wallet.balance()) || [];
+    const initialBal = normalizeCashuBalance(await wallet.balance());
     console.log("initialBal", initialBal);
     set({
       walletBalance: initialBal,
@@ -381,8 +382,8 @@ export const useNostrWalletStore = create((set, get) => ({
       await cashuWallet.checkProofs();
 
       //update the balance after the spend event occurs, deducting 1 sat from your deposits
-      const updatedBalance = await cashuWallet.balance();
-      set({ walletBalance: updatedBalance || [] });
+      const updatedBalance = normalizeCashuBalance(await cashuWallet.balance());
+      set({ walletBalance: updatedBalance });
     } catch (e) {
       console.error("Error sending nutzap:", e);
       setError(e.message);
@@ -446,10 +447,10 @@ export const useNostrWalletStore = create((set, get) => ({
       await cashuWallet.checkProofs(); //sanity check, probably not needed
 
       // get new balance
-      const updatedBalance = await cashuWallet.balance();
+      const updatedBalance = normalizeCashuBalance(await cashuWallet.balance());
 
       //updates balance state, probably triggers wallet listeners too
-      set({ walletBalance: updatedBalance || [] });
+      set({ walletBalance: updatedBalance });
 
       setInvoice("");
       window.location.reload();

--- a/src/utility/cashu.js
+++ b/src/utility/cashu.js
@@ -1,0 +1,41 @@
+export const getCashuBalanceTotal = (balance) => {
+  if (!balance) {
+    return 0;
+  }
+
+  if (Array.isArray(balance)) {
+    return balance.reduce((sum, entry) => sum + (entry?.amount ?? 0), 0);
+  }
+
+  if (typeof balance === "number") {
+    return balance;
+  }
+
+  if (typeof balance === "object") {
+    if (Array.isArray(balance?.balances)) {
+      return balance.balances.reduce(
+        (sum, entry) => sum + (entry?.amount ?? 0),
+        0
+      );
+    }
+
+    if (Array.isArray(balance?.proofs)) {
+      return balance.proofs.reduce((sum, proof) => sum + (proof?.amount ?? 0), 0);
+    }
+
+    if (typeof balance.amount === "number") {
+      return balance.amount;
+    }
+
+    if (typeof balance.balance === "number") {
+      return balance.balance;
+    }
+  }
+
+  return 0;
+};
+
+export const normalizeCashuBalance = (balance) => {
+  const total = getCashuBalanceTotal(balance);
+  return total < 0 ? 0 : total;
+};


### PR DESCRIPTION
## Summary
- add a shared Cashu balance utility to normalize the shapes returned by the NDK wallet
- store numeric wallet balances and reuse the helper across the wallet store and UI so deposits and sends update reliably
- refresh onboarding/help text to reflect the new numeric balance handling

## Testing
- npm run lint *(fails: cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_68e42f0b9edc8326a696a46c5a8991f5